### PR TITLE
Implement authorization with selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,15 +392,11 @@ dependencies = [
 [[package]]
 name = "cedar-policy"
 version = "4.5.1"
-source = "git+https://github.com/cedar-policy/cedar.git?rev=82784864c01b5096cb73885dd2df5643074355ed#82784864c01b5096cb73885dd2df5643074355ed"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
  "itertools 0.14.0",
- "lalrpop-util",
- "lazy_static",
  "miette",
- "nonempty",
  "ref-cast",
  "semver",
  "serde",
@@ -413,7 +409,6 @@ dependencies = [
 [[package]]
 name = "cedar-policy-core"
 version = "4.5.1"
-source = "git+https://github.com/cedar-policy/cedar.git?rev=82784864c01b5096cb73885dd2df5643074355ed#82784864c01b5096cb73885dd2df5643074355ed"
 dependencies = [
  "chrono",
  "educe",
@@ -421,7 +416,6 @@ dependencies = [
  "itertools 0.14.0",
  "lalrpop",
  "lalrpop-util",
- "lazy_static",
  "miette",
  "nonempty",
  "ref-cast",
@@ -439,11 +433,9 @@ dependencies = [
 [[package]]
 name = "cedar-policy-formatter"
 version = "4.5.1"
-source = "git+https://github.com/cedar-policy/cedar.git?rev=82784864c01b5096cb73885dd2df5643074355ed#82784864c01b5096cb73885dd2df5643074355ed"
 dependencies = [
  "cedar-policy-core",
  "itertools 0.14.0",
- "lazy_static",
  "logos",
  "miette",
  "pretty",
@@ -454,7 +446,6 @@ dependencies = [
 [[package]]
 name = "cedar-policy-symcc"
 version = "0.1.0"
-source = "git+https://github.com/cedar-policy/cedar.git?rev=82784864c01b5096cb73885dd2df5643074355ed#82784864c01b5096cb73885dd2df5643074355ed"
 dependencies = [
  "async-recursion",
  "cedar-policy",
@@ -1589,6 +1580,7 @@ dependencies = [
  "itertools 0.14.0",
  "k8s-openapi",
  "kube",
+ "nonempty",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arc-swap"
@@ -344,9 +344,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "block-buffer"
@@ -380,9 +380,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "jobserver",
  "libc",
@@ -407,7 +407,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -432,7 +432,7 @@ dependencies = [
  "serde_with",
  "smol_str",
  "stacker",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "unicode-security",
 ]
 
@@ -466,7 +466,7 @@ dependencies = [
  "num-traits",
  "ref-cast",
  "smol_str",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -990,9 +990,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1097,13 +1097,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1111,6 +1112,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1346,7 +1348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -1443,7 +1445,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1518,7 +1520,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tower",
@@ -1541,7 +1543,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1556,7 +1558,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -1565,7 +1567,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1597,7 +1599,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1652,9 +1654,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1663,7 +1665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1904,7 +1906,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -1934,7 +1936,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -1974,7 +1976,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2044,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -2181,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2191,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -2276,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -2476,7 +2478,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.3.0",
 ]
 
 [[package]]
@@ -2511,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2593,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -2652,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -2779,9 +2781,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -2794,9 +2796,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2869,9 +2871,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2918,11 +2920,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2938,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2999,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3014,9 +3016,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3327,9 +3329,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -3503,11 +3505,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3599,7 +3601,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3620,10 +3622,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,20 @@ edition = "2021"
 anyhow = "1.0.98"
 axum = {version = "0.8.4", features = ["http2", "macros"]}
 axum-server = { version = "0.7.2", features = ["tls-rustls"]}
-cedar-policy = { git = "https://github.com/cedar-policy/cedar.git", rev = "82784864c01b5096cb73885dd2df5643074355ed", features = ["tpe"] }
-cedar-policy-core = { git = "https://github.com/cedar-policy/cedar.git", rev = "82784864c01b5096cb73885dd2df5643074355ed", features = ["tpe"] }
-cedar-policy-symcc = { git = "https://github.com/cedar-policy/cedar.git", rev = "82784864c01b5096cb73885dd2df5643074355ed" }
+#cedar-policy = { git = "https://github.com/cedar-policy/cedar.git", rev = "82784864c01b5096cb73885dd2df5643074355ed", features = ["tpe"] }
+#cedar-policy-core = { git = "https://github.com/cedar-policy/cedar.git", rev = "82784864c01b5096cb73885dd2df5643074355ed", features = ["tpe"] }
+#cedar-policy-symcc = { git = "https://github.com/cedar-policy/cedar.git", rev = "82784864c01b5096cb73885dd2df5643074355ed" }
 
-# cedar-policy = { path = "../cedar/cedar-policy", features = ["tpe"] }
-# cedar-policy-core = { path = "../cedar/cedar-policy-core", features = ["tpe"] }
-# cedar-policy-symcc = { path = "../cedar/cedar-policy-symcc" }
+cedar-policy = { path = "../cedar/cedar-policy", features = ["tpe"] }
+cedar-policy-core = { path = "../cedar/cedar-policy-core", features = ["tpe"] }
+cedar-policy-symcc = { path = "../cedar/cedar-policy-symcc" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 http = "1.3.1"
 itertools = "0.14.0"
 k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 kube = { version = "1.1.0", features = ["client", "runtime"] }
+nonempty = { version = "0.12.0", features = ["serialize"] }
 opentelemetry = { version = "0.30.0", features = ["trace", "logs"] }
 opentelemetry-otlp = "0.30.0"
 opentelemetry-stdout = "0.30.0"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ results here and/or later in Cedar Access Control for Kubernetes.
 
 Let Lucas know if you have feedback or ideas.
 
+**NOTE:** This project is an experiment, and is not yet ready for production
+use. Do not under any circumstances use it in production. This is not an Upbound
+product.
+
 ## Context
 
 By design, Kubernetes authorization operates only on _metadata_, on attributes

--- a/localdev/mount/e2e.cedar
+++ b/localdev/mount/e2e.cedar
@@ -9,6 +9,9 @@ permit(
     resource.request.v1.type == "crossplane.io/connection-secret"
 };
 
+// CEL rule v1: has(object.type) && object.type == "crossplane.io/connection-secret"
+// CEL rule v2: has(object.type2) && object.type2 == "crossplane.io/connection-secret"
+
 permit(
     principal,
     action == k8s::Action::"create",

--- a/localdev/mount/e2e.cedarschema
+++ b/localdev/mount/e2e.cedarschema
@@ -147,10 +147,17 @@ namespace core {
     "apiVersion": __cedar::String,        // always "v1"
     "kind": __cedar::String,              // always "Pod"
     "metadata"?: meta::V1ObjectMeta,
-    "v1"?: core::V1Secret
+    "v1"?: core::V1Secret,
+    "v2"?: core::V2Secret
   };
   entity V1Secret = {
     "type": __cedar::String,
+    "data"?: meta::StringToStringMap,
+    "stringData"?: meta::StringToStringMap,
+    "immutable": __cedar::Bool,
+  };
+  entity V2Secret = {
+    "type2": __cedar::String,
     "data"?: meta::StringToStringMap,
     "stringData"?: meta::StringToStringMap,
     "immutable": __cedar::Bool,

--- a/src/cedar_authorizer/authorizer.rs
+++ b/src/cedar_authorizer/authorizer.rs
@@ -1,20 +1,28 @@
-use cedar_policy_core::validator::json_schema::{CommonTypeId, NamespaceDefinition};
-use cedar_policy_core::validator::{json_schema, RawName};
+use cedar_policy_core::entities::Schema;
+use cedar_policy_core::extensions::Extensions;
+use cedar_policy_core::validator::json_schema::{
+    ActionEntityUID, CommonTypeId, NamespaceDefinition,
+};
+use cedar_policy_core::validator::{json_schema, RawName, ValidatorSchema};
+use cedar_policy_symcc::solver::Solver;
 use k8s_openapi::api::core::v1 as corev1;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
 use kube::core::GroupVersion;
 use kube::runtime::reflector;
 use kube::{self};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-use cedar_policy_core::tpe::entities::PartialEntities;
+use cedar_policy_core::tpe::entities::{PartialEntities, PartialEntity};
 use cedar_policy_core::tpe::request::PartialRequest;
 
-use cedar_policy_core::ast::{Annotation, AnyId, Name, UnreservedId};
+use cedar_policy_core::ast::{self, Annotation, AnyId, Name, UnreservedId};
 
-use crate::cedar_authorizer::kube_invariants::DetailedDecision;
+use crate::cedar_authorizer::entitybuilder::PartialValue;
 use crate::cedar_authorizer::kube_invariants::{self};
+use crate::cedar_authorizer::kube_invariants::{ActionCapability, DetailedDecision};
+use crate::cedar_authorizer::symcc;
 use crate::k8s_authorizer::StarWildcardStringSelector;
 use crate::k8s_authorizer::{
     Attributes, AuthorizerError, EmptyWildcardStringSelector, KubernetesAuthorizer, ParseError,
@@ -22,8 +30,9 @@ use crate::k8s_authorizer::{
 };
 use crate::k8s_authorizer::{CombinedResource, RequestType};
 use crate::schema::core::{
-    ENTITY_NAMESPACE, ENTITY_OBJECTMETA, K8S_NS, PRINCIPAL_NODE, PRINCIPAL_SERVICEACCOUNT,
-    PRINCIPAL_UNAUTHENTICATEDUSER, PRINCIPAL_USER, RESOURCE_NONRESOURCEURL, RESOURCE_RESOURCE,
+    ENTITY_NAMESPACE, ENTITY_OBJECTMETA, K8S_NONRESOURCE_NS, K8S_NS, PRINCIPAL_NODE,
+    PRINCIPAL_SERVICEACCOUNT, PRINCIPAL_UNAUTHENTICATEDUSER, PRINCIPAL_USER,
+    RESOURCE_NONRESOURCEURL, RESOURCE_RESOURCE,
 };
 
 use super::entitybuilder::{BuiltEntity, EntityBuilder, RecordBuilder, RecordBuilderImpl};
@@ -53,16 +62,28 @@ static API_GROUP_ANNOTATION: LazyLock<AnyId> = LazyLock::new(|| "apiGroup".parse
 // TODO: Disallow usage of "is k8s::Resource", such that we do not need to do authorization requests separately for "untyped" and "typed" variants?
 //   If we make it such that (given you restrict the verb to some resource verb) you MUST keep the policy open to all typed variants, then
 //   we probably have an easier time analyzing as well who has access to some given resource, and we don't need rewrites from untyped -> typed worlds.
-pub struct CedarKubeAuthorizer<S: KubeStore<corev1::Namespace>> {
+pub struct CedarKubeAuthorizer<
+    S: KubeStore<corev1::Namespace>,
+    F: symcc::SolverFactory<C>,
+    C: Solver,
+> {
     policies: kube_invariants::PolicySet,
     namespaces: S,
+    symcc_evaluator: symcc::SymbolicEvaluator<F, C>,
     // k8s_ns: &'a NamespaceDefinition<RawName>,
 }
 
-impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
+impl<S: KubeStore<corev1::Namespace>, F: symcc::SolverFactory<C>, C: Solver>
+    CedarKubeAuthorizer<S, F, C>
+{
     // TODO: Add possibility to dynamically update the schema and policies later as well.
-    pub fn new(policies: kube_invariants::PolicySet, namespaces: S) -> Result<Self, SchemaError> {
+    pub fn new(
+        policies: kube_invariants::PolicySet,
+        namespaces: S,
+        symcc_factory: F,
+    ) -> Result<Self, SchemaError> {
         Ok(Self {
+            symcc_evaluator: symcc::SymbolicEvaluator::new(policies.schema(), symcc_factory)?,
             policies,
             namespaces,
         })
@@ -75,10 +96,18 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
         }
 
         let mut entity_builder: EntityBuilder = EntityBuilder::new()
-            .with_attr("username", Some(attrs.user.name.as_str()))
-            .with_string_set("groups", Some(attrs.user.groups.iter().map(|s| s.as_str())))
-            .with_attr("uid", attrs.user.uid.as_deref())
-            .with_string_to_stringset_map("extra", Some(&attrs.user.extra));
+            .with_attr("username", attrs.user.name.to_smolstr())
+            .with_attr(
+                "groups",
+                attrs
+                    .user
+                    .groups
+                    .iter()
+                    .map(|s| s.to_smolstr())
+                    .collect::<HashSet<_>>(),
+            )
+            .with_attr("uid", attrs.user.uid.as_ref())
+            .with_attr("extra", attrs.user.extra.clone());
 
         let mut principal_type = PRINCIPAL_USER.name.name();
 
@@ -91,8 +120,8 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
                 ));
             }
 
-            entity_builder.add_attr("serviceAccountNamespace", Some(parts[0]));
-            entity_builder.add_attr("serviceAccountName", Some(parts[1]));
+            entity_builder.add_attr("serviceAccountNamespace", parts[0]);
+            entity_builder.add_attr("serviceAccountName", parts[1]);
 
             principal_type = PRINCIPAL_SERVICEACCOUNT.name.name();
         } else if let Some(nodename) = attrs.user.name.strip_prefix("system:node:") {
@@ -104,73 +133,67 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
             }
             principal_type = PRINCIPAL_NODE.name.name();
             // TODO: Add some validation here
-            entity_builder.add_attr("nodeName", Some(nodename));
+            entity_builder.add_attr("nodeName", nodename);
         }
 
         Ok(entity_builder.build(principal_type))
     }
 
-    fn namespace_entity(&self, ns_name: &str) -> Result<BuiltEntity, AuthorizerError> {
+    /*fn namespace_entity(&self, ns_name: &str) -> Result<BuiltEntity, AuthorizerError> {
         let stored_ns = self.namespaces.get(&reflector::ObjectRef::new(ns_name));
         let stored_ns_metadata = stored_ns.as_ref().map(|ns| &ns.metadata);
 
         Ok(EntityBuilder::new()
             // Note: resource.namespace.name is populated (if non-wildcard), although the namespace
             // does not exist in Kubernetes, and thus no metadata is available (left unknown).
-            .with_attr("name", Some(ns_name))
-            // TODO: Should this entity also have a deterministic UID; as
-            .with_metadata(match stored_ns_metadata {
-                Some(ns_metadata) => Some(ns_metadata),
-                None => None,
-            })
+            .with_attr("name", ns_name)
+            .with_attr(
+                "metadata",
+                match stored_ns_metadata {
+                    Some(ns_metadata) => PartialValue::Known(ns_metadata),
+                    None => PartialValue::Unknown,
+                },
+            )
             .build(ENTITY_NAMESPACE.name.name()))
-    }
+    }*/
 
-    fn construct_resource(
-        &self,
-        attrs: &Attributes,
-    ) -> Result<(BuiltEntity, bool), AuthorizerError> {
+    fn construct_resource(&self, attrs: &Attributes, action_capability: &ActionCapability) -> Result<(BuiltEntity, Option<bool>), AuthorizerError> {
         match &attrs.request_type {
-            RequestType::NonResource(nonresource_attrs) => Ok((
-                EntityBuilder::new()
-                    .with_attr(
-                        "path",
-                        Some(EntityBuilder::unknown_string(
-                            match nonresource_attrs.path {
-                                StarWildcardStringSelector::Any => None,
-                                _ => Some(nonresource_attrs.path.to_string()),
-                            },
-                        )),
-                    )
-                    .build(RESOURCE_NONRESOURCEURL.name.name()),
-                false,
-            )),
+            RequestType::NonResource(nonresource_attrs) => Ok((EntityBuilder::new()
+                .with_attr(
+                    "path",
+                    match nonresource_attrs.path {
+                        StarWildcardStringSelector::Any => PartialValue::Unknown,
+                        _ => PartialValue::Known(nonresource_attrs.path.to_string().to_smolstr()),
+                    },
+                )
+                .build(RESOURCE_NONRESOURCEURL.name.name()), None)),
             RequestType::Resource(resource_attrs) => {
                 let mut resource_builder = EntityBuilder::new()
                     .with_attr(
                         "apiGroup",
-                        Some(EntityBuilder::unknown_string(
-                            match resource_attrs.api_group {
-                                StarWildcardStringSelector::Any => None,
-                                _ => Some(resource_attrs.api_group.to_string()),
-                            },
-                        )),
-                    )
-                    .with_attr(
-                        "name",
-                        Some(EntityBuilder::unknown_string(match resource_attrs.name {
-                            EmptyWildcardStringSelector::Any => None,
-                            _ => Some(resource_attrs.name.to_string()),
-                        })),
+                        match resource_attrs.api_group {
+                            StarWildcardStringSelector::Any => PartialValue::Unknown,
+                            _ => PartialValue::Known(
+                                resource_attrs.api_group.to_string().to_smolstr(),
+                            ),
+                        },
                     )
                     .with_attr(
                         "resourceCombined",
-                        Some(EntityBuilder::unknown_string(
-                            match resource_attrs.resource {
-                                CombinedResource::Any => None,
-                                _ => Some(resource_attrs.resource.to_string()),
-                            },
-                        )),
+                        match resource_attrs.resource {
+                            CombinedResource::Any => PartialValue::Unknown,
+                            _ => PartialValue::Known(
+                                resource_attrs.resource.to_string().to_smolstr(),
+                            ),
+                        },
+                    )
+                    .with_attr(
+                        "name",
+                        match resource_attrs.name {
+                            EmptyWildcardStringSelector::Any => PartialValue::Unknown,
+                            _ => PartialValue::Known(resource_attrs.name.to_string().to_smolstr()),
+                        },
                     );
 
                 match (&resource_attrs.api_group, &resource_attrs.resource) {
@@ -191,24 +214,22 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
                             resource_type,
                         )) => {
                             let record = entity_to_record(resource_type)?;
-                            resource_builder.add_attr(
-                                "namespace",
-                                match &resource_attrs.namespace {
-                                    EmptyWildcardStringSelector::Any => {
-                                        match record.attributes.contains_key("namespace") {
-                                            // An unset namespace for a namespaced resource means "any".
-                                            true => Some(EntityBuilder::build_unknown(
-                                                ENTITY_NAMESPACE.name.name(),
-                                            )),
-                                            // An unset namespace for a cluster-scoped resource means "none".
-                                            false => None,
+                            
+                            // Only populate the namespace field if there is such an attribute in the schema.
+                            // The namespace is never set for a cluster-scoped resource
+                            // If the SAR specifies some exact namespace for a cluster-scoped resource,
+                            // the SAR value is ignored. TODO: Check if this is the case also for k8s RBAC.
+                            if record.attributes.contains_key("namespace") {
+                                resource_builder.add_attr(
+                                    "namespace",
+                                    match &resource_attrs.namespace {
+                                        EmptyWildcardStringSelector::Any => PartialValue::Unknown,
+                                        EmptyWildcardStringSelector::Exact(ns_name) => {
+                                            PartialValue::Known(ns_name.to_smolstr())
                                         }
-                                    }
-                                    EmptyWildcardStringSelector::Exact(ns_name) => {
-                                        Some(self.namespace_entity(ns_name.as_str())?)
-                                    }
-                                },
-                            );
+                                    },
+                                );
+                            }
 
                             // TODO: Enforce all these invariants early on, instead of here (late).
                             // In that case, we can guard against ever starting to consider a faulty schema and
@@ -221,91 +242,90 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
                                         GroupVersion::gv(api_group, api_version)
                                             .api_version()
                                             .into();
-                                    resource_builder.add_attr(
-                                        "request",
-                                        match record.attributes.get("request") {
-                                            Some(_) => match attrs.verb {
-                                                // In authorization, keep resource.request unknown for the verbs which
-                                                // carry request data.
-                                                Verb::Create
-                                                | Verb::Update
-                                                | Verb::Patch
-                                                | Verb::Connect => {
-                                                    let versioned_record = resource_type_namespace.common_types.get(&CommonTypeId::new(format!("Versioned{kind}").parse::<UnreservedId>().unwrap()).unwrap())
-                                                    .ok_or_else(|| AuthorizerError::UnexpectedSchemaShape("schema should have common type registered at GVR resource entity".to_string()))?;
-                                                    let versioned_record = type_to_record(&versioned_record.ty)?;
-                                                    let specific_version_attr = versioned_record.attributes.get(api_version.as_str());
 
-                                                    Some(RecordBuilderImpl::new()
+                                    // TODO: For now, we only populate the namespace metadata if conditional authorization is supported, in other words,
+                                    // only when VAP is enabled. If decisions were computed directly based on namespace metadata (e.g. unconditional allow or deny),
+                                    // then authorization would become state-dependent, and return varying results for the same SAR, depending on mutable etcd state.
+                                    // In practice, the Node authorizer is state-dependent, but that is a specialized use-case, and we need to be careful to expose such things
+                                    // to the policy author in a way that could be confusing. The general idea would be that authorization is stateless, and must return cacheable
+                                    // responses, but then the enforcement point (e.g. the API server) is able to allow/deny individual requests based on data in etcd.
+                                    // In the future, one could consider adding the ability to operate on namespace metadata for list, watch, deletecollection verbs as well,
+                                    // those cannot be supported before the API server is able to enforce conditions for such requests.
+                                    // It might also be unintuitive that the precondition on namespace metadata existing, is that the API version is an exact match.
+                                    // Given these specific circumstances when this field is available, it is hard to say whether it is more confusing than helpful.
+                                    match (record.attributes.contains_key("namespaceMetadata"), action_capability.supports_conditional_decision()) {
+                                        (true, true) => {
+                                            resource_builder.add_attr::<&str, PartialValue<&metav1::ObjectMeta>>("namespaceMetadata", PartialValue::Unknown);
+                                        }
+                                        (_, _) => (),
+                                    }
+
+                                    match (record.attributes.contains_key("request"), action_capability.has_request_object()) {
+                                        (true, true) => {
+                                            let versioned_record = resource_type_namespace.common_types.get(&CommonTypeId::new(format!("Versioned{kind}").parse::<UnreservedId>().unwrap()).unwrap())
+                                            .ok_or_else(|| AuthorizerError::UnexpectedSchemaShape("schema should have common type registered at GVR resource entity".to_string()))?;
+                                            let versioned_record = type_to_record(&versioned_record.ty)?;
+                                            let specific_version_attr = versioned_record.attributes.get(api_version.as_str());
+                                            resource_builder.add_attr(
+                                                "request",
+                                        
+                                                    RecordBuilderImpl::new()
                                                     .with_attr("apiVersion", Some(api_group_version.clone()))
                                                     .with_attr("kind", Some(kind.clone()))
                                                     // Only expose the metadata field if there a) the apiVersion is an exact match, and b) the given apiVersion exists in the schema.
-                                                    .with_attr("metadata", specific_version_attr.map(|_| EntityBuilder::build_unknown(ENTITY_OBJECTMETA.name.name())))
-                                                    .with_attr(api_version.as_str(), specific_version_attr.map(|_| EntityBuilder::build_unknown(format!("{}{}", &crate::util::title_case(api_version), &kind).parse::<Name>().unwrap().qualify_with_name(resource_type_namespace_name.as_ref())))))
-                                                }
-                                                // For verbs that do not carry request data, make "resource has request" return false.
-                                                _ => None,
-                                            },
-                                            // If the type does not have a request, ok, don't add anything.
-                                            None => None,
+                                                    .with_attr::<&str, PartialValue<&metav1::ObjectMeta>>("metadata", match specific_version_attr {
+                                                        Some(_) => PartialValue::Unknown,
+                                                        None => PartialValue::Unset,
+                                                    })
+                                                    // TODO: Use partialvalue here and unknown/unset instead of this Option<Unknown> style
+                                                    .with_attr(api_version.as_str(), specific_version_attr.map(|_| EntityBuilder::build_unknown(format!("{}{}", &crate::util::title_case(api_version), &kind).parse::<Name>().unwrap().qualify_with_name(resource_type_namespace_name.as_ref()))))
+                                                );
                                         },
-                                    );
-
-                                    resource_builder.add_attr(
-                                        "stored",
-                                        match record.attributes.get("stored") {
-                                            Some(_) => match attrs.verb {
-                                                // In authorization, keep resource.request unknown for the verbs which
-                                                // carry request data.
-                                                // TODO: Do we get any stored data for connect verbs?
-                                                // TODO: Should we allow arbitrary verbs to operate conditionally?
-                                                // TODO: Actually make this known, and populate the apiVersion & kind fields
-                                                // Keep metadata unknown, but also only populate one of the versioned fields.
-                                                Verb::Get
-                                                | Verb::List
-                                                | Verb::Watch
-                                                | Verb::Update
-                                                | Verb::Patch
-                                                | Verb::Delete
-                                                | Verb::DeleteCollection => {
-                                                    let versioned_record = resource_type_namespace.common_types.get(&CommonTypeId::new(format!("Versioned{kind}").parse::<UnreservedId>().unwrap()).unwrap())
+                                        // For verbs that do not carry request data, make "resource has request" return false.
+                                        (true, false) => (),
+                                        // If the type does not have a request, ok, don't add anything.
+                                        (false, _) => (),
+                                    };
+                                    
+                                    match (record.attributes.contains_key("stored"), action_capability.has_stored_object()) {
+                                        (true, true) => {
+                                            let versioned_record = resource_type_namespace.common_types.get(&CommonTypeId::new(format!("Versioned{kind}").parse::<UnreservedId>().unwrap()).unwrap())
                                                     .ok_or_else(|| AuthorizerError::UnexpectedSchemaShape("schema should have common type registered at GVR resource entity".to_string()))?;
-                                                    let versioned_record = type_to_record(&versioned_record.ty)?;
-                                                    let specific_version_attr = versioned_record.attributes.get(api_version.as_str());
+                                            let versioned_record = type_to_record(&versioned_record.ty)?;
+                                            let specific_version_attr = versioned_record.attributes.get(api_version.as_str());
 
-                                                    Some(RecordBuilderImpl::new()
+                                            resource_builder.add_attr(
+                                                "stored",
+                                                RecordBuilderImpl::new()
                                                     .with_attr("apiVersion", Some(api_group_version.clone()))
                                                     .with_attr("kind", Some(kind.clone()))
                                                     // Only expose the metadata field if there a) the apiVersion is an exact match, and b) the given apiVersion exists in the schema.
-                                                    .with_attr("metadata", specific_version_attr.map(|_| EntityBuilder::build_unknown(ENTITY_OBJECTMETA.name.name())))
-                                                    .with_attr(api_version.as_str(), specific_version_attr.map(|_| EntityBuilder::build_unknown(format!("{}{}", &crate::util::title_case(api_version), &kind).parse::<Name>().unwrap().qualify_with_name(resource_type_namespace_name.as_ref())))))
-                                                }
-                                                // For verbs that do not carry request data, make "resource has request" return false.
-                                                _ => None,
-                                            },
-                                            // If the type does not have a stored value, ok, don't add anything.
-                                            None => None,
+                                                    .with_attr::<&str, PartialValue<&metav1::ObjectMeta>>("metadata", match specific_version_attr {
+                                                        Some(_) => PartialValue::Unknown,
+                                                        None => PartialValue::Unset,
+                                                    })
+                                                    .with_attr(api_version.as_str(), specific_version_attr.map(|_| EntityBuilder::build_unknown(format!("{}{}", &crate::util::title_case(api_version), &kind).parse::<Name>().unwrap().qualify_with_name(resource_type_namespace_name.as_ref()))))
+                                                );
                                         },
-                                    );
+                                        // For verbs that do not have stored data, make "resource has stored" return false.
+                                        (true, false) => (),
+                                        // If the type does not have a stored object, ok, don't add anything.
+                                        (false, _) => (),
+                                    }
                                 }
-                                // If the apiVersion is an any match, resource.stored and resource.request are nil, but unlike
-                                // the untyped case (k8s::Resource), the specific resource entity type is used (e.g. core::pods)
+                                // If the apiVersion is an any match, resource.stored, resource.request, and resource.namespaceMetadata are nil, but unlike
+                                // the untyped case (k8s::Resource), the specific resource entity type is used (e.g. core::pods).
                                 StarWildcardStringSelector::Any => (),
                             }
 
-                            Ok((
-                                resource_builder.build(
-                                    Name::unqualified_name(typed_resource_entity_id)
-                                        .qualify_with_name(resource_type_namespace_name.as_ref()),
-                                ),
-                                true,
-                            ))
+                            Ok((resource_builder.build(
+                                Name::unqualified_name(typed_resource_entity_id)
+                                    .qualify_with_name(resource_type_namespace_name.as_ref()),
+                            ), Some(record.attributes.contains_key("namespace"))))
                         }
                         // Untyped k8s::Resource case, due to to the resource requested not being in the schema,
                         // e.g. due to discovery not being up to date, or the requested resource begin "virtual".
-                        None => {
-                            self.finish_building_untyped_resource(resource_builder, resource_attrs)
-                        }
+                        None => self.finish_building_untyped_resource(resource_builder, resource_attrs),
                     },
                     // Untyped k8s::Resource case, due to multiple possible resource type matches.
                     _ => self.finish_building_untyped_resource(resource_builder, resource_attrs),
@@ -318,29 +338,23 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
         &self,
         resource_builder: EntityBuilder,
         resource_attrs: &ResourceAttributes,
-    ) -> Result<(BuiltEntity, bool), AuthorizerError> {
-        Ok((
-            resource_builder
-                .with_attr(
-                    "namespace",
-                    match &resource_attrs.namespace {
-                        // Here we must assume that the namespace is "any",
-                        // as we're arbitrarily selecting across a (possibly infinite) set of k8s resource types.
-                        // However, in theory all matched resources could be cluster-scoped (imagine apiGroup="foo" and resource="*"),
-                        // where all resources in apiGroup="foo" are cluster-scoped. If so, it would be better to make "resource has namespace"
-                        // queries return "false", but this we cannot know, we lose a little bit of precision here.
-                        // TODO: Create a Cedar issue to discuss whether "foo has bar" should be able to be unknown, which is what we want here.
-                        EmptyWildcardStringSelector::Any => {
-                            Some(EntityBuilder::build_unknown(ENTITY_NAMESPACE.name.name()))
-                        }
-                        EmptyWildcardStringSelector::Exact(ns_name) => {
-                            Some(self.namespace_entity(ns_name.as_str())?)
-                        }
-                    },
-                )
-                .build(RESOURCE_RESOURCE.name.name()),
-            false,
-        ))
+    ) -> Result<(BuiltEntity, Option<bool>), AuthorizerError> {
+        Ok((resource_builder
+            .with_attr(
+                "namespace",
+                match &resource_attrs.namespace {
+                    // Here we cannot distinguish between namespace being "any" or "unset". We assume that the namespace is "any",
+                    // as we're arbitrarily selecting across a (possibly infinite) set of k8s resource types.
+                    // However, in theory all matched resources could be cluster-scoped (imagine apiGroup="foo" and resource="*"),
+                    // where all resources in apiGroup="foo" are cluster-scoped. If so, it would be better to make "resource has namespace"
+                    // queries return "false", but this we cannot know, we lose a little bit of precision here.
+                    // TODO: Create a Cedar issue to discuss whether "foo has bar" should be able to be unknown, which is what we want here.
+                    EmptyWildcardStringSelector::Any => PartialValue::Unknown,
+                    EmptyWildcardStringSelector::Exact(ns_name) => PartialValue::Known(ns_name.to_smolstr())
+                },
+            )
+            // None here means that we don't know whether the resource is namespace-scoped or cluster-scoped.
+            .build(RESOURCE_RESOURCE.name.name()), None))
     }
 
     fn find_schema_entity_for_api_group_and_resource<'a>(
@@ -375,35 +389,50 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
     }
 
     // INVARIANT: verb is validated to exist in the schema already.
-    fn is_authorized_for_action(
+    async fn is_authorized_for_action(
         &self,
         attrs: &Attributes,
         action: &str,
+        action_schemadef: &json_schema::ActionType<RawName>,
+        cedar_ns_name: &Option<Name>,
     ) -> Result<DetailedDecision, AuthorizerError> {
-        // Check both typed and untyped actions, if applicable.
-        // There is a typed action only if
-        // a) the action is get, list, watch, create, update, patch, delete, deletecollection, and
-        // b) the resource refers to a resource type in the schema.
-
+        let action_capability = self
+            .policies
+            .schema_ref()
+            .get_action_capabilities(cedar_ns_name, action);
         // TODO: Unit-test the construct_principal/resource functions.
         let principal_entity = self.construct_principal(attrs)?;
-        // TODO: Derive typed_resource from the uid of the built entity.
-        let (resource_entity, typed_resource) = self.construct_resource(attrs)?;
+        let (resource_entity, namespace_scoped) = self.construct_resource(attrs, &action_capability)?;
 
-        let action_entity = if resource_entity
-            .uid()
-            .to_string()
-            .starts_with("k8s::nonresource::")
-        {
-            format!(r#"k8s::nonresource::Action::"{action}""#).parse()?
-        } else {
-            format!(r#"k8s::Action::"{action}""#).parse()?
+        let principal_entity_uid = principal_entity.uid().clone();
+        let resource_entity_uid = resource_entity.uid().clone();
+        //let cedar_ns_internalname = cedar_ns_name.as_ref().map(|n| n.as_ref());
+        let action_entity_uid: ast::EntityUID = match &attrs.request_type {
+            RequestType::Resource(_) => format!(r#"k8s::Action::"{action}""#).parse()?,
+            RequestType::NonResource(_) => {
+                format!(r#"k8s::nonresource::Action::"{action}""#).parse()?
+            }
+        };
+        let code_schema =
+            cedar_policy_core::validator::CoreSchema::new(self.policies.schema_ref().as_ref());
+        let action_entity = PartialEntity {
+            uid: action_entity_uid.clone(),
+            attrs: None,
+            ancestors: Some(
+                code_schema
+                    .action(&action_entity_uid)
+                    .expect("INVARIANT: action existence in the schema is checked in is_authorized")
+                    .ancestors()
+                    .cloned()
+                    .collect(),
+            ),
+            tags: None,
         };
 
         let req = PartialRequest::new(
-            principal_entity.uid().clone().into(),
-            action_entity,
-            resource_entity.uid().clone().into(),
+            principal_entity_uid.clone().into(),
+            action_entity_uid.clone(),
+            resource_entity_uid.clone().into(),
             None,
             self.policies.schema().as_ref().as_ref(),
         )?;
@@ -416,7 +445,11 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
         let entities = PartialEntities::from_entities(
             principal_entities
                 .into_iter()
-                .chain(resource_entities.into_iter()),
+                .chain(resource_entities.into_iter())
+                .chain(std::iter::once((
+                    action_entity_uid.clone().into(),
+                    action_entity,
+                ))),
             self.policies.schema().as_ref().as_ref(),
         )?;
 
@@ -426,19 +459,51 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
             DetailedDecision::Allow(permitted_policy_ids) => {
                 DetailedDecision::Allow(permitted_policy_ids)
             }
-            // For the untyped case, the parts that may be conditional, are actually known, but just kept unknown, as they can have any value.
-            // Thus, if we get a conditional decision for an untyped request, there is some condition on "any value", which thus must evaluate to false.
-            // TODO: Rejecting allow rules is easy, but rejecting deny rules for this reason seems dangerous?
             DetailedDecision::Conditional(condition, unknown_jsonpaths_to_uid) => {
-                if typed_resource {
-                    DetailedDecision::Conditional(
-                        condition,
-                        unknown_jsonpaths_to_uid
-                            .into_iter()
-                            .chain(principal_jsonpaths)
-                            .chain(resource_jsonpaths)
-                            .collect(),
-                    )
+                //println!("conditional decision: {condition}");
+
+                // Union all the unknown jsonpaths.
+                let unknown_jsonpaths_to_uid = unknown_jsonpaths_to_uid
+                .into_iter()
+                .chain(principal_jsonpaths)
+                .chain(resource_jsonpaths)
+                .collect();
+
+                // For conditional authorization to be supported, apiGroup, apiVersion, and resource must be exact matches.
+                // TODO: Should label selector authorization be allowed, even though we don't know the resource type?
+                if let Some((_, api_version, _)) = attrs.supports_conditional_authorization() {
+
+                    if action_capability.supports_conditional_decision() {
+                        DetailedDecision::Conditional(
+                            condition,
+                            unknown_jsonpaths_to_uid,
+                        )
+                    } else if action_capability.supports_selectors() {
+                        let reqenv = cedar_policy::RequestEnv::new(
+                            principal_entity_uid.entity_type().clone().into(),
+                            action_entity_uid.into(),
+                            resource_entity_uid.entity_type().clone().into(),
+                        );
+
+                        match self
+                            .symcc_evaluator
+                            .selector_conditions_are_authorized(&attrs, &reqenv, condition, unknown_jsonpaths_to_uid, &api_version, namespace_scoped.unwrap_or(true))
+                            .await?
+                        {
+                            // TODO: Fill in these, although we don't know exactly which allow policy fired.
+                            true => DetailedDecision::Allow(Vec::from([ast::PolicyID::from_string("conditional_authorization")])),
+                            // TODO: Fill in these, although we don't know exactly which deny policy fired; or if it was due to no matching allow rules.
+                            false => DetailedDecision::Deny(Vec::from([ast::PolicyID::from_string("conditional_authorization")])),
+                        }
+                    } else {
+                        // For the untyped case, the parts that may be conditional, are actually known, but just kept unknown, as they can have any value.
+                        // Thus, if we get a conditional decision for an untyped request, there is some condition on "any value", which thus must evaluate to false.
+                        // TODO: Rejecting allow rules is easy, but rejecting deny rules for this reason seems dangerous?
+                        // TODO: If the resource is an untyped resource request, it might still need symcc,
+                        // because of the 'resource.resourceCombined like "*/scale"' expressions.
+                        // However, that could also be solved without symcc, by manual traversal for the specific use-case.
+                        DetailedDecision::NoOpinion
+                    }
                 } else {
                     DetailedDecision::NoOpinion
                 }
@@ -451,166 +516,147 @@ impl<S: KubeStore<corev1::Namespace>> CedarKubeAuthorizer<S> {
     }
 }
 
-impl<S: KubeStore<corev1::Namespace>> KubernetesAuthorizer for CedarKubeAuthorizer<S> {
-    fn is_authorized(&self, mut attrs: Attributes) -> Result<Response, AuthorizerError> {
-        // Check that verb is supported in schema
-        // If * => check with every action in schema in subroutine
+impl<
+        S: KubeStore<corev1::Namespace> + Send + Sync,
+        F: symcc::SolverFactory<C> + Send + Sync,
+        C: Solver + Send + Sync,
+    > KubernetesAuthorizer for CedarKubeAuthorizer<S, F, C>
+{
+    fn is_authorized(
+        &self,
+        mut attrs: Attributes,
+    ) -> impl std::future::Future<Output = Result<Response, AuthorizerError>> + Send {
+        async move {
+            let action_str = attrs.verb.to_string();
+            let cedar_ns_name = match &mut attrs.request_type {
+                RequestType::Resource(resource_attrs) => {
+                    // Lookup the action capabilities for the resource request. An error is returned if the action is not supported.
+                    let action_capability = self
+                        .policies
+                        .schema_ref()
+                        .get_action_capabilities(&K8S_NS, &action_str);
+                    if action_capability.supports_selectors() {
+                        // Populate the resource attributes from the field selectors, if present.
+                        resource_attrs.default_from_selectors()?;
+                    } else {
+                        resource_attrs.field_selector = None;
+                        resource_attrs.label_selector = None;
+                    }
+                    &K8S_NS
+                }
+                RequestType::NonResource(_) => {
+                    // Lookup the action capabilities for the non-resource request. An error is returned if the action is not supported.
+                    &K8S_NONRESOURCE_NS
+                }
+            };
 
-        let schema = self.policies.schema();
-        let k8s_ns = schema
-            .get_namespace(&K8S_NS)
-            .ok_or(AuthorizerError::NoKubernetesNamespace)?;
+            let cedar_ns = self
+                .policies
+                .schema_ref()
+                .get_namespace(cedar_ns_name)
+                .ok_or_else(|| {
+                    AuthorizerError::UnexpectedSchemaShape(format!(
+                        "schema should have {cedar_ns_name:?} namespace registered"
+                    ))
+                })?;
 
-        let verb_str = attrs.verb.to_string();
-        if !k8s_ns.actions.contains_key(verb_str.as_str()) {
-            return Err(AuthorizerError::UnsupportedVerb(verb_str));
-        }
+            let action_schemadef = match cedar_ns.actions.get(action_str.as_str()) {
+                Some(action_schemadef) => action_schemadef,
+                None => return Err(AuthorizerError::UnsupportedVerb(action_str)),
+            };
 
-        // Populate the resource attributes from the field selectors, if present.
-        match &mut attrs.request_type {
-            RequestType::Resource(resource_attrs) => {
-                default_from_selectors(resource_attrs)?;
-            }
-            RequestType::NonResource(_) => (),
-        }
+            match attrs.verb {
+                // If the action is Any, verify that all actions are unconditionally allowed.
+                Verb::Any => {
+                    let errors = Vec::new();
+                    let mut allowed_ids = HashSet::new();
+                    // TODO: Check the * action first, then others.
+                    // Deliberately shadow the action_str and action_schemadef variables so they aren't accidentally used.
+                    for (action_str, action_schemadef) in cedar_ns.actions.iter() {
+                        let resp = self
+                            .is_authorized_for_action(
+                                &attrs,
+                                action_str.as_str(),
+                                action_schemadef,
+                                &cedar_ns_name,
+                            )
+                            .await?;
+                        // TODO: Propagate errors?
 
-        match attrs.verb {
-            Verb::Any => {
-                let errors = Vec::new();
-                let mut allowed_ids = HashSet::new();
-                // TODO: Check the * action first, then others.
-                for (action, _) in k8s_ns.actions.iter() {
-                    let resp = self.is_authorized_for_action(&attrs, action.as_str())?;
-                    // TODO: Propagate errors?
-
-                    match resp {
-                        DetailedDecision::Allow(permitted_policy_ids) => {
-                            allowed_ids.extend(permitted_policy_ids.into_iter())
-                        }
-                        DetailedDecision::Conditional(conditions, _) => {
-                            return Ok(Response::no_opinion().with_errors(errors).with_reason(
-                                Reason::not_unconditionally_allowed(action, &conditions),
-                            ))
-                        }
-                        DetailedDecision::Deny(forbidden_policy_ids) => {
-                            return Ok(Response::no_opinion().with_errors(errors).with_reason(
-                                Reason::denied_by_policies(action, &forbidden_policy_ids),
-                            ))
-                        }
-                        DetailedDecision::NoOpinion => {
-                            return Ok(Response::no_opinion().with_errors(errors))
+                        match resp {
+                            DetailedDecision::Allow(permitted_policy_ids) => {
+                                allowed_ids.extend(permitted_policy_ids.into_iter())
+                            }
+                            DetailedDecision::Conditional(conditions, _) => {
+                                return Ok(Response::no_opinion().with_errors(errors).with_reason(
+                                    Reason::not_unconditionally_allowed(action_str, &conditions),
+                                ))
+                            }
+                            DetailedDecision::Deny(forbidden_policy_ids) => {
+                                return Ok(Response::no_opinion().with_errors(errors).with_reason(
+                                    Reason::denied_by_policies(action_str, &forbidden_policy_ids),
+                                ))
+                            }
+                            // TODO: Add as reason that a specific action is not unconditionally allowed.
+                            DetailedDecision::NoOpinion => {
+                                return Ok(Response::no_opinion()
+                                    .with_errors(errors)
+                                    .with_reason(Reason::no_allow_policy_match(action_str)))
+                            }
                         }
                     }
+                    // TODO: Add all policies that allowed the action as reason?
+                    Ok(Response::allow().with_errors(errors))
                 }
-
-                Ok(Response::allow().with_errors(errors))
-            }
-            // Semantics:
-            // - If there are any true denies, deny.
-            // (- If there are any folded true denies, deny.)
-            // We can add this optimization later.
-            // - If there are any residual denies (that do not fold to false), conditional
-            // TODO: Should we give full context here; i.e. including foldable residual forbid policies?
-            // In the beginning, we do not do this, but keep things simple.
-            // The permit policies could potentially just be folded into "true", if there is at least one true.
-            // - If there are any true allows, allow.
-            // - NOTE: Do not fold allows to true, only to false.
-            // - If there are any residual allows (that do not fold to false), conditional
-            //   At this point, it is known that there are no residual denies.
-            // - Otherwise (only false denies and allows, or none), no opinion.
-            // TODO: Maybe we want still to fold here too?
-            _ => {
-                let action_str = attrs.verb.to_string();
-                match self.is_authorized_for_action(&attrs, &action_str)? {
-                    // TODO: Propagate errors
-                    DetailedDecision::Allow(permitted_policy_ids) => Ok(Response::allow()
-                        .with_reason(Reason::allowed_by_policies(
+                // Semantics:
+                // - If there are any true denies, deny.
+                // (- If there are any folded true denies, deny.)
+                // We can add this optimization later.
+                // - If there are any residual denies (that do not fold to false), conditional
+                // TODO: Should we give full context here; i.e. including foldable residual forbid policies?
+                // In the beginning, we do not do this, but keep things simple.
+                // The permit policies could potentially just be folded into "true", if there is at least one true.
+                // - If there are any true allows, allow.
+                // - NOTE: Do not fold allows to true, only to false.
+                // - If there are any residual allows (that do not fold to false), conditional
+                //   At this point, it is known that there are no residual denies.
+                // - Otherwise (only false denies and allows, or none), no opinion.
+                // TODO: Maybe we want still to fold here too?
+                _ => {
+                    match self
+                        .is_authorized_for_action(
+                            &attrs,
                             &action_str,
-                            &permitted_policy_ids,
-                        ))),
-                    DetailedDecision::Deny(forbidden_policy_ids) => Ok(Response::no_opinion()
-                        .with_reason(Reason::denied_by_policies(
-                            &action_str,
-                            &forbidden_policy_ids,
-                        ))),
-                    DetailedDecision::Conditional(
-                        conditional_policies,
-                        unknown_jsonpaths_to_uid,
-                    ) => Ok(Response::conditional(
-                        conditional_policies,
-                        unknown_jsonpaths_to_uid,
-                    )),
-                    DetailedDecision::NoOpinion => Ok(Response::no_opinion()
-                        .with_reason(Reason::no_allow_policy_match(&action_str))),
+                            action_schemadef,
+                            &cedar_ns_name,
+                        )
+                        .await?
+                    {
+                        // TODO: Propagate errors
+                        DetailedDecision::Allow(permitted_policy_ids) => Ok(Response::allow()
+                            .with_reason(Reason::allowed_by_policies(
+                                &action_str,
+                                &permitted_policy_ids,
+                            ))),
+                        DetailedDecision::Deny(forbidden_policy_ids) => Ok(Response::no_opinion()
+                            .with_reason(Reason::denied_by_policies(
+                                &action_str,
+                                &forbidden_policy_ids,
+                            ))),
+                        DetailedDecision::Conditional(
+                            conditional_policies,
+                            unknown_jsonpaths_to_uid,
+                        ) => Ok(Response::conditional(
+                            conditional_policies,
+                            unknown_jsonpaths_to_uid,
+                        )),
+                        DetailedDecision::NoOpinion => Ok(Response::no_opinion()
+                            .with_reason(Reason::no_allow_policy_match(&action_str))),
+                    }
                 }
             }
         }
     }
-}
-
-// TODO: Should we validate to only allow only field selectors for specific verbs?
-// TODO: The more generic solution here is to allow multiple values for a field selector,
-// get a residual, and use the SAT/SMT/symbolic compiler method to make sure that all possible values
-// are authorized.
-fn default_from_selectors(built_resource_attrs: &mut ResourceAttributes) -> Result<(), ParseError> {
-    if let Some(field_selectors) = &built_resource_attrs.field_selector {
-        for field_selector in field_selectors {
-            match field_selector.key.as_str() {
-                // Populate the name field from the field selector, if present, like Kubernetes does.
-                "metadata.name" => {
-                    match (&built_resource_attrs.name, field_selector.exact_match()) {
-                        // Fold the field selector value into the spec requirement, just like Kubernetes RequestInfo code does.
-                        (EmptyWildcardStringSelector::Any, Some(fieldselector_name)) => {
-                            built_resource_attrs.name =
-                                EmptyWildcardStringSelector::Exact(fieldselector_name);
-                        }
-                        // No requirements, nothing to do.
-                        (EmptyWildcardStringSelector::Any, None) => (),
-                        // If name is specified both in the SAR spec and in the field selector, they must match.
-                        (
-                            EmptyWildcardStringSelector::Exact(spec_name),
-                            Some(fieldselector_name),
-                        ) => {
-                            if spec_name.as_str() != fieldselector_name {
-                                return Err(ParseError::InvalidFieldSelectorRequirement(format!("if metadata.name is specified both on the SubjectAccessReview spec ({spec_name}) and in the field selector ({fieldselector_name}), they must match")));
-                            }
-                        }
-                        // This is the usual case, name is specified in the SAR spec, but no field selector is present.
-                        (EmptyWildcardStringSelector::Exact(_), None) => (),
-                    }
-                }
-                // Populate the namespace field from the field selector in the similar manner, however, UNLIKE Kubernetes.
-                // We here choose to be consistent with the way we populate the name field, and not Kubernetes.
-                "metadata.namespace" => {
-                    match (
-                        &built_resource_attrs.namespace,
-                        field_selector.exact_match(),
-                    ) {
-                        // Fold the field selector value into the spec requirement.
-                        (EmptyWildcardStringSelector::Any, Some(fieldselector_namespace)) => {
-                            built_resource_attrs.namespace =
-                                EmptyWildcardStringSelector::Exact(fieldselector_namespace);
-                        }
-                        // No requirements, nothing to do.
-                        (EmptyWildcardStringSelector::Any, None) => (),
-                        // If namespace is specified both in the SAR spec and in the field selector, they must match.
-                        (
-                            EmptyWildcardStringSelector::Exact(spec_namespace),
-                            Some(fieldselector_namespace),
-                        ) => {
-                            if spec_namespace.as_str() != fieldselector_namespace {
-                                return Err(ParseError::InvalidFieldSelectorRequirement(format!("if metadata.namespace is specified both on the SubjectAccessReview spec ({spec_namespace}) and in the field selector ({fieldselector_namespace}), they must match")));
-                            }
-                        }
-                        // This is the usual case, namespace is specified in the SAR spec, but no field selector is present.
-                        (EmptyWildcardStringSelector::Exact(_), None) => (),
-                    }
-                }
-                _ => (),
-            }
-        }
-    }
-    Ok(())
 }
 
 // TODO: This should be upstreamed to cedar-policy-core.
@@ -678,8 +724,8 @@ fn type_to_record(
 
 mod test {
 
-    #[test]
-    fn test_is_authorized() {
+    #[tokio::test]
+    async fn test_is_authorized() {
         use super::super::kubestore::TestKubeStore;
         use crate::cedar_authorizer::kube_invariants;
         use crate::k8s_authorizer::test_utils::AttributesBuilder;
@@ -694,6 +740,7 @@ mod test {
         use k8s_openapi::api::core::v1 as corev1;
         use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
 
+        use crate::cedar_authorizer::symcc::LocalSolverFactory;
         use std::collections::{BTreeMap, HashMap};
         use std::str::FromStr;
         use std::sync::Arc;
@@ -718,6 +765,18 @@ mod test {
                 },
                 ..Default::default()
             },
+            /*corev1::Namespace {
+                metadata: metav1::ObjectMeta {
+                    name: Some("supersecret".to_string()),
+                    uid: Some("1e00c0eb-ec4c-41a2-bb59-e7dea5b21b50".to_string()),
+                    labels: Some(BTreeMap::from([(
+                        "serviceaccounts-allowed".to_string(),
+                        "true".to_string(),
+                    )])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },*/
             corev1::Namespace {
                 metadata: metav1::ObjectMeta {
                     name: Some("bar".to_string()),
@@ -737,7 +796,8 @@ mod test {
             super::kube_invariants::PolicySet::new(policies.as_ref(), Arc::new(schema.clone()))
                 .unwrap();
 
-        let authorizer = super::CedarKubeAuthorizer::new(policies, namespace_store).unwrap();
+        let authorizer =
+            super::CedarKubeAuthorizer::new(policies, namespace_store, LocalSolverFactory).unwrap();
 
         // TODO: Fix validation problem with nonresourceurl and any verb.
         let test_cases = vec![
@@ -765,60 +825,43 @@ mod test {
                     EmptyWildcardStringSelector::Any,
                     EmptyWildcardStringSelector::Any)
                 .build(), Response::no_opinion()),
-            ("serviceaccount can get pods in its own namespace",
-            AttributesBuilder::resource("system:serviceaccount:foo:bar", Verb::Get,
-                    StarWildcardStringSelector::Exact("".to_string()),
-                    StarWildcardStringSelector::Any,
-                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
-                    EmptyWildcardStringSelector::Exact("foo".to_string()),
-                    EmptyWildcardStringSelector::Any)
-                .build(), Response::allow()),
-            ("serviceaccount can get pods in its own namespace, but through a field selector",
-            AttributesBuilder::resource_and_selectors("system:serviceaccount:foo:bar", Verb::Get,
-                    StarWildcardStringSelector::Exact("".to_string()),
-                    StarWildcardStringSelector::Any,
-                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
-                    EmptyWildcardStringSelector::Any,
-                    EmptyWildcardStringSelector::Any,
-                    None,
-                    Some(vec![Selector::in_values("metadata.namespace", false, vec!["foo".to_string()])])
-                )
-                .build(), Response::allow()),
-            ("serviceaccount can get pods in its own namespace, but not in the supersecret namespace",
-            AttributesBuilder::resource("system:serviceaccount:supersecret:bar", Verb::Get,
-                    StarWildcardStringSelector::Exact("".to_string()),
-                    StarWildcardStringSelector::Any,
-                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
-                    EmptyWildcardStringSelector::Exact("supersecret".to_string()),
-                    EmptyWildcardStringSelector::Any)
-                .build(), Response::no_opinion()),
-            ("serviceaccount can get pods in a namespace which does not have the label",
-            AttributesBuilder::resource("system:serviceaccount:bar:bar", Verb::Get,
-                    StarWildcardStringSelector::Exact("".to_string()),
-                    StarWildcardStringSelector::Any,
-                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
-                    EmptyWildcardStringSelector::Exact("bar".to_string()),
-                    EmptyWildcardStringSelector::Any)
-                .build(), Response::no_opinion()),
-            ("serviceaccount can conditionally get pods in a namespace which is not in the storage",
-            AttributesBuilder::resource("system:serviceaccount:baz:baz", Verb::Get,
+            ("serviceaccount can create pods in its own namespace, if the namespace has the label",
+            AttributesBuilder::resource("system:serviceaccount:foo:bar", Verb::Create,
                     StarWildcardStringSelector::Exact("".to_string()),
                     StarWildcardStringSelector::Exact("v1".to_string()),
                     CombinedResource::ResourceOnly { resource: "pods".to_string() },
-                    EmptyWildcardStringSelector::Exact("baz".to_string()),
+                    EmptyWildcardStringSelector::Exact("foo".to_string()),
                     EmptyWildcardStringSelector::Any)
                 .build(), Response::conditional(kube_invariants::PolicySet::from_str(r#"permit(
     principal,
     action,
     resource
 ) when {
-(((meta::V1ObjectMeta::"0610f71c-7aab-4153-a235-afe4280a59f5"["labels"]).hasTag("serviceaccounts-allowed")) && (((meta::V1ObjectMeta::"0610f71c-7aab-4153-a235-afe4280a59f5"["labels"]).getTag("serviceaccounts-allowed")) == "true"))
+(meta::V1ObjectMeta::"85388367-1edd-4bc3-8627-4cb36fa65130" has "labels") &&
+(meta::V1ObjectMeta::"85388367-1edd-4bc3-8627-4cb36fa65130"["labels"]).hasTag("serviceaccounts-allowed") &&
+(meta::V1ObjectMeta::"85388367-1edd-4bc3-8627-4cb36fa65130"["labels"]).getTag("serviceaccounts-allowed") == "true"
 };"#, Arc::new(schema.clone())).unwrap(), HashMap::from([
-    ("resource.name".to_string(), r#"meta::UnknownString::"222fa568-eb07-411c-a6ff-b6eab75392dc""#.parse().unwrap()),
-    ("resource.namespace.metadata".to_string(), r#"meta::V1ObjectMeta::"0610f71c-7aab-4153-a235-afe4280a59f5""#.parse().unwrap()),
-    ("resource.stored.v1".to_string(), r#"core::V1Pod::"03600274-f607-4061-8080-fb1f7adc63a4""#.parse().unwrap()),
-    ("resource.stored.metadata".to_string(), r#"meta::V1ObjectMeta::"9c869675-8159-4f4d-b8c0-2173efe8142b""#.parse().unwrap()),
+    ("resource.name".to_string(), r#"meta::UnknownString::"899b04c3-0d65-4375-95d9-b643da26c747""#.parse().unwrap()),
+    ("resource.namespaceMetadata".to_string(), r#"meta::V1ObjectMeta::"85388367-1edd-4bc3-8627-4cb36fa65130""#.parse().unwrap()),
+    ("resource.request.v1".to_string(), r#"core::V1Pod::"20fa9537-3d09-4628-9841-cdc26099bf64""#.parse().unwrap()),
+    ("resource.request.metadata".to_string(), r#"meta::V1ObjectMeta::"f9144f25-4359-4efe-80a2-3b74ed5bc57c""#.parse().unwrap()),
 ]))),
+            ("serviceaccount cannot create pods in another namespace",
+            AttributesBuilder::resource("system:serviceaccount:foo:bar", Verb::Create,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
+                    EmptyWildcardStringSelector::Exact("notmatchingfoo".to_string()),
+                    EmptyWildcardStringSelector::Any)
+                .build(), Response::no_opinion()),
+            ("serviceaccount cannot create pods in the supersecret namespace",
+            AttributesBuilder::resource("system:serviceaccount:supersecret:bar", Verb::Create,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
+                    EmptyWildcardStringSelector::Exact("supersecret".to_string()),
+                    EmptyWildcardStringSelector::Any)
+                .build(), Response::no_opinion()),
             ("anonymous user can get openapi v2",
             AttributesBuilder::nonresource("system:anonymous", Verb::Get,
                 StarWildcardStringSelector::Exact("/openapi/v2".to_string()))
@@ -851,23 +894,42 @@ mod test {
                     EmptyWildcardStringSelector::Any,
                     EmptyWildcardStringSelector::Exact("node-2".to_string()))
                 .build(), Response::no_opinion()),
-            ("a node can get pods in the foo namespace",
-            AttributesBuilder::resource("system:node:node-1", Verb::Get,
+            ("node-1 can watch its own pods cluster-wide, except in the supersecret namespace",
+            AttributesBuilder::resource_and_selectors("system:node:node-1", Verb::Watch,
                     StarWildcardStringSelector::Exact("".to_string()),
                     StarWildcardStringSelector::Exact("v1".to_string()),
                     CombinedResource::ResourceOnly { resource: "pods".to_string() },
-                    EmptyWildcardStringSelector::Exact("foo".to_string()),
-                    EmptyWildcardStringSelector::Exact("pod-abc".to_string()))
-                .build(), Response::conditional(kube_invariants::PolicySet::from_str(r#"permit(
-  principal,
-  action,
-  resource
-) when {
-  ((core::V1Pod::"80f44bb4-96d6-46bb-8c3e-ca5c797a04e8" has "spec") && ((((core::V1Pod::"80f44bb4-96d6-46bb-8c3e-ca5c797a04e8")["spec"])["nodeName"]) == "node-1"))
-};"#, Arc::new(schema.clone())).unwrap(), HashMap::from([
-    ("resource.stored.v1".to_string(), r#"core::V1Pod::"80f44bb4-96d6-46bb-8c3e-ca5c797a04e8""#.parse().unwrap()),
-    ("resource.stored.metadata".to_string(), r#"meta::V1ObjectMeta::"b7b65842-3d3a-48a8-8239-0f48010c1867""#.parse().unwrap()),
-]))),
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    None,
+                    Some(vec![
+                        Selector::in_values("spec.nodeName", vec!["node-1".to_string()]),
+                        Selector::not_in_values("metadata.namespace", vec!["supersecret".to_string()]),
+                    ]))
+                .build(), Response::allow()),
+            ("node-1 cannot watch all pods cluster-wide",
+            AttributesBuilder::resource_and_selectors("system:node:node-1", Verb::Watch,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    None,
+                    None)
+                    .build(), Response::no_opinion()),
+            ("node-1 cannot watch pods cluster-wide when spec.nodeName is either node-1 or node-2",
+            AttributesBuilder::resource_and_selectors("system:node:node-1", Verb::Watch,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "pods".to_string() },
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    None,
+                    Some(vec![
+                        Selector::in_values("spec.nodeName", vec!["node-1".to_string(), "node-2".to_string()]),
+                        Selector::not_in_values("metadata.namespace", vec!["supersecret".to_string()]),
+                    ]))
+                .build(), Response::no_opinion()),
             ("lucas can get pods in the notinstorage namespace",
             AttributesBuilder::resource("lucas", Verb::Get,
                     StarWildcardStringSelector::Exact("".to_string()),
@@ -913,8 +975,8 @@ mod test {
                     EmptyWildcardStringSelector::Any,
                     None,
                     Some(vec![
-                        Selector::in_values("metadata.namespace", false, vec!["foo".to_string()]),
-                        Selector::in_values("metadata.name", false, vec!["bar".to_string()]),
+                        Selector::in_values("metadata.namespace", vec!["foo".to_string()]),
+                        Selector::in_values("metadata.name", vec!["bar".to_string()]),
                     ])
                 )
                 .build(), Response::allow()),
@@ -927,16 +989,75 @@ mod test {
                         EmptyWildcardStringSelector::Any,
                         None,
                         Some(vec![
-                            Selector::in_values("metadata.namespace", false, vec!["foo".to_string()]),
-                            Selector::in_values("metadata.name", false, vec!["bar".to_string()]),
+                            Selector::in_values("metadata.namespace", vec!["foo".to_string()]),
+                            Selector::in_values("metadata.name", vec!["bar".to_string()]),
                         ])
                     )
+                    .build(), Response::no_opinion()),
+            ("contour can list secrets cluster-wide (except the supersecret namespace), if the secret has the correct labels",
+            AttributesBuilder::resource_and_selectors("system:serviceaccount:foo:contour", Verb::List,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "secrets".to_string() },
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    Some(vec![
+                        Selector::in_values("allowed-ingress", vec!["contour".to_string(), "*".to_string()]),
+                        Selector::not_in_values("clearancelevel", vec!["supersecret".to_string(), "confidential".to_string()]),
+                    ]),
+                    Some(vec![
+                        Selector::not_in_values("metadata.namespace", vec!["supersecret".to_string()]),
+                    ]))
+                    .build(), Response::allow()),
+            ("contour cannot list istio's secrets cluster-wide, if the secret has the correct labels",
+            AttributesBuilder::resource_and_selectors("system:serviceaccount:foo:contour", Verb::List,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "secrets".to_string() },
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    Some(vec![
+                        Selector::in_values("allowed-ingress", vec!["contour".to_string(), "*".to_string(), "istio".to_string()]),
+                        Selector::not_in_values("clearancelevel", vec!["supersecret".to_string(), "confidential".to_string()]),
+                    ]),
+                    Some(vec![
+                        Selector::not_in_values("metadata.namespace", vec!["supersecret".to_string()]),
+                    ]))
+                    .build(), Response::no_opinion()),
+            ("contour cannot list secrets cluster-wide, if confidential secrets could match the label selector",
+            AttributesBuilder::resource_and_selectors("system:serviceaccount:foo:contour", Verb::List,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "secrets".to_string() },
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    Some(vec![
+                        Selector::in_values("allowed-ingress", vec!["contour".to_string(), "*".to_string()]),
+                        Selector::not_in_values("clearancelevel", vec!["supersecret".to_string()]),
+                    ]),
+                    Some(vec![
+                        Selector::not_in_values("metadata.namespace", vec!["supersecret".to_string()]),
+                    ]))
+                    .build(), Response::no_opinion()),
+            ("contour cannot list secrets cluster-wide, if confidential or supersecret secrets could match the label selector (whole clearancelevel label selector omitted)",
+            AttributesBuilder::resource_and_selectors("system:serviceaccount:foo:contour", Verb::List,
+                    StarWildcardStringSelector::Exact("".to_string()),
+                    StarWildcardStringSelector::Exact("v1".to_string()),
+                    CombinedResource::ResourceOnly { resource: "secrets".to_string() },
+                    EmptyWildcardStringSelector::Any,
+                    EmptyWildcardStringSelector::Any,
+                    Some(vec![
+                        Selector::in_values("allowed-ingress", vec!["contour".to_string(), "*".to_string()]),
+                    ]),
+                    Some(vec![
+                        Selector::not_in_values("metadata.namespace", vec!["supersecret".to_string()]),
+                    ]))
                     .build(), Response::no_opinion()),
         ];
 
         for (description, attrs, expected_resp) in test_cases {
             println!("{description}");
-            let resp = authorizer.is_authorized_response(attrs);
+            let resp = authorizer.is_authorized_response(attrs).await;
             assert_eq!(
                 expected_resp.decision, resp.decision,
                 "got {} with reason: {}, errors: {:?}",

--- a/src/cedar_authorizer/cel.rs
+++ b/src/cedar_authorizer/cel.rs
@@ -11,8 +11,8 @@ pub enum CedarToCelError {
     UnsupportedOperator(cedar_ast::BinaryOp),
     #[error("Unsupported Cedar extension function: {0}")]
     UnsupportedExtensionFunction(String),
-//    #[error("CEL parser error: {0}")]
-//    CELParseError(#[from] cel::parser::ParseError),
+    //    #[error("CEL parser error: {0}")]
+    //    CELParseError(#[from] cel::parser::ParseError),
 }
 
 pub trait EntityToCelVariableMapper {
@@ -293,7 +293,7 @@ pub fn cedar_to_cel<M: EntityToCelVariableMapper>(
     }
 }
 
-mod test {
+/*mod test {
     #[test]
     fn test_cel_expression() {
         use serde_json::json;
@@ -382,7 +382,7 @@ mod test {
                 r#"resource.apiGroup.endsWith('/scale')"#,
             ),
             (
-                r#"resource.apiGroup like "*/scale/*""#,
+                r#"resource.apiGroup like "/scale/""#,
                 r#"resource.apiGroup.matches('.*\\/scale\\/.*')"#,
             ),
         ];
@@ -394,7 +394,7 @@ mod test {
         }
     }
 
-    /*#[test]
+    #[test]
     fn test_other_cel_library() {
         let env = cel_cxx::Env::builder()
             .declare_variable::<String>("name").unwrap()
@@ -410,5 +410,5 @@ mod test {
 
         let result = program.evaluate(&activation).unwrap();
         assert_eq!(result, true.into());
-    }*/
-}
+    }
+}*/

--- a/src/cedar_authorizer/entitybuilder.rs
+++ b/src/cedar_authorizer/entitybuilder.rs
@@ -67,11 +67,6 @@ impl EntityBuilder {
         }
     }
 
-    // TODO: Make this cleaner?
-    /*pub(super) fn build_unknown_internal_name(entity_type_name: InternalName) -> BuiltEntity {
-        Self::build_unknown(entity_type_name.to_string().parse().unwrap())
-    }*/
-
     pub(super) fn build(mut self, entity_type_name: Name) -> BuiltEntity {
         let eid = match self.entity_eid {
             Some(eid) => eid,

--- a/src/cedar_authorizer/entitybuilder.rs
+++ b/src/cedar_authorizer/entitybuilder.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{LazyLock, Mutex};
 
 use cedar_policy_core::{
-    ast::{Eid, EntityType, EntityUID, InternalName, Literal, Name, Value},
+    ast::{Eid, EntityType, EntityUID, Literal, Name, Value},
     tpe::entities::PartialEntity,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
@@ -277,9 +277,9 @@ impl IntoValueWithEntities for &metav1::ObjectMeta {
         HashMap<String, EntityUID>,
     ) {
         EntityBuilder::new()
-            .with_attr("labels", self.labels.as_ref().map(|m| m.clone()))
-            .with_attr("annotations", self.annotations.as_ref().map(|m| m.clone()))
-            .with_attr("finalizers", self.finalizers.as_ref().map(|s| s.clone()))
+            .with_attr("labels", self.labels.clone())
+            .with_attr("annotations", self.annotations.clone())
+            .with_attr("finalizers", self.finalizers.clone())
             .with_attr("uid", self.uid.as_ref().map(|s| s.to_smolstr()))
             .with_attr("deleted", self.deletion_timestamp.is_some())
             .build(ENTITY_OBJECTMETA.name.name())

--- a/src/cedar_authorizer/fork.rs
+++ b/src/cedar_authorizer/fork.rs
@@ -1,16 +1,16 @@
 use cedar_policy_core::{expr_builder::ExprBuilder, parser::Loc};
-use smol_str::SmolStr;
 use nonempty::NonEmpty;
+use smol_str::SmolStr;
 
-use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
-    process::{Child, ChildStdin, ChildStdout, Command},
-};
-use std::{path::Path, process::Stdio};
 use cedar_policy_symcc::{
     err::SolverError,
     solver::{Decision, Solver},
     SmtLibScript,
+};
+use std::{path::Path, process::Stdio};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    process::{Child, ChildStdin, ChildStdout, Command},
 };
 
 // NOTE: This is a copy of the original function in cedar-policy-core.
@@ -68,14 +68,13 @@ pub(super) fn construct_exprs_extended_has<Build: ExprBuilder>(
         .0
 }
 
-
 /// Implements `Solver` by launching an SMT solver in a new process and
 /// communicating with it
-/// 
+///
 /// Note: This is a modified copy of the original struct in cedar-policy-symcc.
 /// Filename: cedar/cedar-policy-symcc/src/symcc/solver.rs
 /// The code is Apache-2.0 licensed by the Cedar contributors.
-/// 
+///
 /// This LocalSolver is slightly modified to drop the solver process when the
 /// LocalSolver is dropped. I'm not sure if that happens with the original
 /// LocalSolver. In any case, once it is made sure that the Cedar upstream

--- a/src/cedar_authorizer/fork.rs
+++ b/src/cedar_authorizer/fork.rs
@@ -1,0 +1,191 @@
+use cedar_policy_core::{expr_builder::ExprBuilder, parser::Loc};
+use smol_str::SmolStr;
+use nonempty::NonEmpty;
+
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    process::{Child, ChildStdin, ChildStdout, Command},
+};
+use std::{path::Path, process::Stdio};
+use cedar_policy_symcc::{
+    err::SolverError,
+    solver::{Decision, Solver},
+    SmtLibScript,
+};
+
+// NOTE: This is a copy of the original function in cedar-policy-core.
+// Filename: cedar/cedar-policy-core/src/parser/cst_to_ast.rs
+// The code is Apache-2.0 licensed by the Cedar contributors.
+// Hopefully, one would be able to make this function public in the future,
+// to avoid the copy here.
+pub(super) fn construct_exprs_extended_has<Build: ExprBuilder>(
+    t: Build::Expr,
+    attrs: &NonEmpty<SmolStr>,
+    loc: Option<&Loc>,
+) -> Build::Expr {
+    let (first, rest) = attrs.split_first();
+    let has_expr = Build::new()
+        .with_maybe_source_loc(loc)
+        .has_attr(t.clone(), first.to_owned());
+    let get_expr = Build::new()
+        .with_maybe_source_loc(loc)
+        .get_attr(t, first.to_owned());
+    // Foldl on the attribute list
+    // It produces the following for `principal has contactInfo.address.zip`
+    //     Expr.and
+    //   (Expr.and
+    //     (Expr.hasAttr (Expr.var .principal) "contactInfo")
+    //     (Expr.hasAttr
+    //       (Expr.getAttr (Expr.var .principal) "contactInfo")
+    //       "address"))
+    //   (Expr.hasAttr
+    //     (Expr.getAttr
+    //       (Expr.getAttr (Expr.var .principal) "contactInfo")
+    //       "address")
+    //     "zip")
+    // This is sound. However, the evaluator has to recur multiple times to the
+    // left-most node to evaluate the existence of the first attribute. The
+    // desugared expression should be the following to avoid the issue above,
+    // Expr.and
+    //   Expr.hasAttr (Expr.var .principal) "contactInfo"
+    //   (Expr.and
+    //      (Expr.hasAttr (Expr.getAttr (Expr.var .principal) "contactInfo")"address")
+    //      (Expr.hasAttr ..., "zip"))
+    rest.iter()
+        .fold((has_expr, get_expr), |(has_expr, get_expr), attr| {
+            (
+                Build::new().with_maybe_source_loc(loc).and(
+                    has_expr,
+                    Build::new()
+                        .with_maybe_source_loc(loc)
+                        .has_attr(get_expr.clone(), attr.to_owned()),
+                ),
+                Build::new()
+                    .with_maybe_source_loc(loc)
+                    .get_attr(get_expr, attr.to_owned()),
+            )
+        })
+        .0
+}
+
+
+/// Implements `Solver` by launching an SMT solver in a new process and
+/// communicating with it
+/// 
+/// Note: This is a modified copy of the original struct in cedar-policy-symcc.
+/// Filename: cedar/cedar-policy-symcc/src/symcc/solver.rs
+/// The code is Apache-2.0 licensed by the Cedar contributors.
+/// 
+/// This LocalSolver is slightly modified to drop the solver process when the
+/// LocalSolver is dropped. I'm not sure if that happens with the original
+/// LocalSolver. In any case, once it is made sure that the Cedar upstream
+/// LocalSolver kills the solver process when it is dropped, we can remove this.
+#[derive(Debug)]
+pub struct LocalSolver {
+    solver_stdin: BufWriter<ChildStdin>,
+    solver_stdout: BufReader<ChildStdout>,
+    child: Child,
+}
+
+impl LocalSolver {
+    fn new<'a>(
+        path: impl AsRef<Path>,
+        args: impl IntoIterator<Item = &'a str>,
+    ) -> Result<Self, SolverError> {
+        let mut child = Command::new(path.as_ref())
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+        tracing::debug!("Spawned solver instance with PID: {:?}", child.id());
+        let (stdin, stdout) = match (child.stdin.take(), child.stdout.take()) {
+            (Some(stdin), Some(stdout)) => (stdin, stdout),
+            _ => {
+                return Err(SolverError::Solver(
+                    "Failed to fetch IO pipes for solver process".into(),
+                ))
+            }
+        };
+        Ok(Self {
+            solver_stdin: BufWriter::new(stdin),
+            solver_stdout: BufReader::new(stdout),
+            child,
+        })
+    }
+
+    pub fn cvc5() -> Result<Self, SolverError> {
+        Self::new(
+            std::env::var("CVC5").unwrap_or_else(|_| "cvc5".into()),
+            ["--lang", "smt", "--tlimit=60000"], // limit of 60000ms = 1 min of wall time for local solves, for now
+        )
+    }
+}
+
+impl Solver for LocalSolver {
+    fn smtlib_input(&mut self) -> &mut (dyn tokio::io::AsyncWrite + Unpin + Send) {
+        &mut self.solver_stdin
+    }
+
+    async fn check_sat(&mut self) -> Result<Decision, SolverError> {
+        self.smtlib_input().check_sat().await?;
+        self.solver_stdin.flush().await?;
+        let mut output = String::new();
+        self.solver_stdout.read_line(&mut output).await?;
+        match output.as_str() {
+            "sat\n" => Ok(Decision::Sat),
+            "unsat\n" => Ok(Decision::Unsat),
+            "unknown\n" => Ok(Decision::Unknown),
+            s => match s
+                .strip_prefix("(error \"")
+                .and_then(|s| s.strip_suffix("\")\n"))
+            {
+                Some(e) => Err(SolverError::Solver(e.to_string())),
+                _ => Err(SolverError::UnrecognizedSolverOutput(output)),
+            },
+        }
+    }
+
+    async fn get_model(&mut self) -> Result<Option<String>, SolverError> {
+        self.smtlib_input().get_model().await?;
+        self.solver_stdin.flush().await?;
+        let mut output = String::new();
+
+        // We assume that the output is one of the following forms:
+        // 1. "(\n<the actual model>\n)\n"
+        // 2. "(error ...)\n"
+
+        // Read the first line
+        self.solver_stdout.read_line(&mut output).await?;
+        match output.as_str() {
+            "(\n" => {
+                // Read until a line ")\n"
+                loop {
+                    let len: usize = self.solver_stdout.read_line(&mut output).await?;
+                    if &output[output.len() - len..] == ")\n" {
+                        break;
+                    }
+                }
+                Ok(Some(output))
+            }
+
+            s => match s
+                .strip_prefix("(error \"")
+                .and_then(|s| s.strip_suffix("\")\n"))
+            {
+                Some(e) => Err(SolverError::Solver(e.to_string())),
+                _ => Err(SolverError::UnrecognizedSolverOutput(output)),
+            },
+        }
+    }
+}
+
+impl Drop for LocalSolver {
+    fn drop(&mut self) {
+        if let Some(id) = self.child.id() {
+            tracing::debug!("Dropping solver instance with PID: {}", id);
+        } else {
+            tracing::debug!("Dropping solver instance (process already terminated)");
+        }
+    }
+}

--- a/src/cedar_authorizer/kube_invariants.rs
+++ b/src/cedar_authorizer/kube_invariants.rs
@@ -47,6 +47,7 @@ mod schema;
 pub use err::*;
 pub use policyset::PolicySet;
 pub use residual::{DetailedDecision, PartialResponseNew};
+pub use schema::ActionCapability;
 pub use schema::Schema;
 
 use cedar_policy_core::ast;

--- a/src/cedar_authorizer/kube_invariants/err.rs
+++ b/src/cedar_authorizer/kube_invariants/err.rs
@@ -19,6 +19,8 @@ pub enum SchemaError {
     PolicyIsNotStatic(ast::PolicyID),
     #[error(transparent)]
     EarlyEvaluationError(#[from] EarlyEvaluationError),
+    #[error(transparent)]
+    SolverFactoryError(#[from] crate::cedar_authorizer::symcc::SolverFactoryError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/cedar_authorizer/kube_invariants/schema.rs
+++ b/src/cedar_authorizer/kube_invariants/schema.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, HashSet},
-    fmt::format,
     sync::LazyLock,
 };
 
@@ -11,12 +10,8 @@ use cedar_policy_core::{
 
 use cedar_policy_core::ast::{InternalName, Name, UnreservedId};
 use cedar_policy_core::validator::json_schema::{self, EntityTypeKind, Fragment};
-use smol_str::SmolStr;
 
-use crate::{
-    k8s_authorizer::AuthorizerError,
-    schema::core::{K8S_NONRESOURCE_NS, K8S_NS},
-};
+use crate::schema::core::{K8S_NONRESOURCE_NS, K8S_NS};
 
 use super::err::SchemaError;
 
@@ -122,8 +117,8 @@ impl Schema {
         self.schema.0.get(namespace)
     }
 
-    pub fn get_action_capabilities<'a>(
-        &'a self,
+    pub fn get_action_capabilities(
+        &self,
         namespace: &Option<ast::Name>,
         action: &str,
     ) -> ActionCapability {
@@ -253,6 +248,7 @@ impl AsRef<cedar_policy::Schema> for Schema {
 /// The request_object capability specifies whether the action contains a request object.
 /// The stored_object capability specifies whether the action contains a stored object.
 /// The selectors and request/stored_object capabilities are mutually exclusive.
+#[derive(Default)]
 pub struct ActionCapability {
     selectors: bool,
     request_object: bool,
@@ -289,16 +285,6 @@ impl ActionCapability {
             selectors: false,
             request_object,
             stored_object,
-        }
-    }
-}
-
-impl Default for ActionCapability {
-    fn default() -> Self {
-        Self {
-            selectors: false,
-            request_object: false,
-            stored_object: false,
         }
     }
 }

--- a/src/cedar_authorizer/mod.rs
+++ b/src/cedar_authorizer/mod.rs
@@ -3,6 +3,8 @@ pub mod cel;
 mod entitybuilder;
 pub mod kube_invariants;
 pub mod kubestore;
-mod symcc;
+pub mod symcc;
+mod fork;
 
 pub use authorizer::CedarKubeAuthorizer;
+pub use fork::LocalSolver;

--- a/src/cedar_authorizer/mod.rs
+++ b/src/cedar_authorizer/mod.rs
@@ -1,10 +1,10 @@
 pub mod authorizer;
 pub mod cel;
 mod entitybuilder;
+mod fork;
 pub mod kube_invariants;
 pub mod kubestore;
 pub mod symcc;
-mod fork;
 
 pub use authorizer::CedarKubeAuthorizer;
 pub use fork::LocalSolver;

--- a/src/cedar_authorizer/symcc.rs
+++ b/src/cedar_authorizer/symcc.rs
@@ -372,24 +372,6 @@ impl WithExprBuilder for ast::Expr<()> {
     }
 }
 
-/*struct RestrictedExprBuilder {
-    expr: ast::Expr<()>,
-}
-
-impl RestrictedExprBuilder {
-    fn new<T: Into<ast::Expr<()>>>(expr: T) -> Self {
-        Self { expr: expr.into() }
-    }
-
-    fn and<T: Into<ast::Expr<()>>>(self, other: T) -> Self {
-        Self { expr: ast::Expr::and(self.expr, other.into()) }
-    }
-
-    fn build(self) -> ast::Expr<()> {
-        self.expr
-    }
-}*/
-
 mod test {
     #[test]
     fn test_field_selector_to_expr() {

--- a/src/cedar_authorizer/symcc.rs
+++ b/src/cedar_authorizer/symcc.rs
@@ -1,4 +1,493 @@
+use std::{collections::HashMap, marker::PhantomData, sync::Arc};
+
+use crate::{
+    cedar_authorizer::kube_invariants, k8s_authorizer::{self, Attributes, RequestType, SymbolicEvaluationError},
+};
+use cedar_policy_core::{ast, expr_builder::ExprBuilder};
+use cedar_policy_symcc::{
+    err::SolverError,
+    solver::{Decision, Solver},
+    CedarSymCompiler,
+};
+use nonempty::NonEmpty;
+use itertools::Itertools;
+use smol_str::{SmolStr, ToSmolStr};
+
+use super::fork::LocalSolver;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SolverFactoryError {
+    #[error(transparent)]
+    SolverError(#[from] SolverError),
+    #[error(transparent)]
+    ParserError(#[from] cedar_policy_symcc::err::Error),
+}
+
+pub trait SolverFactory<S: Solver> {
+    fn new_solver(&self) -> Result<S, SolverFactoryError>;
+
+    fn new_sym_compiler(&self) -> Result<CedarSymCompiler<S>, SolverFactoryError> {
+        Ok(CedarSymCompiler::new(self.new_solver()?)?)
+    }
+}
+
+pub struct LocalSolverFactory;
+
+impl SolverFactory<LocalSolver> for LocalSolverFactory {
+    fn new_solver(&self) -> Result<LocalSolver, SolverFactoryError> {
+        Ok(LocalSolver::cvc5()?)
+    }
+}
+
+pub struct SymbolicEvaluator<F: SolverFactory<S>, S: Solver> {
+    symcc_factory: F,
+    schema: Arc<kube_invariants::Schema>,
+    _marker: PhantomData<S>,
+}
+
+impl<F: SolverFactory<S>, S: Solver> SymbolicEvaluator<F, S> {
+    pub fn new(
+        schema: Arc<kube_invariants::Schema>,
+        symcc_factory: F,
+    ) -> Result<Self, SolverFactoryError> {
+        Ok(Self {
+            schema,
+            symcc_factory,
+            _marker: PhantomData,
+        })
+    }
+
+    pub async fn selector_conditions_are_authorized(
+        &self,
+        attrs: &Attributes,
+        reqenv: &cedar_policy::RequestEnv,
+        is_authorized: kube_invariants::PolicySet,
+        unknown_jsonpaths_to_uid: HashMap<String, ast::EntityUID>,
+        api_version: &str,
+        namespace_scoped: bool,
+    ) -> Result<bool, SymbolicEvaluationError> {
+        let cedar_public_api_schema_ref = self.schema.as_ref().as_ref();
+        let symenv = cedar_policy_symcc::SymEnv::new(cedar_public_api_schema_ref, &reqenv)?;
+        
+        
+
+        // TODO: Can we make registering unknowns type-safe by using an enum?
+
+        // TODO: Figure out how errors are handled when a well-typed Cedar PolicySet is
+        // mapped into an SMT Term. Do the semantics of "one allow policy erroring does not affect other allow policies"
+        // hold also in the translation?
+
+        // IMPORTANT: If there are no other requirements in object_selected, it must default to "true", just in case.
+        // Cedar by default turns PolicySets into SMT Terms through the "is_authorized" function, and naturally,
+        // whether an PolicySet authorizes a principal is a static false. However, if object_selected == false, it means
+        // object_selected => is_authorized is a tautology, regardless of is_authorized. In our case, it is kind of the
+        // opposite: absence of restrictions on the request object means that every object selected, and thus should
+        // object_selected == true. However, if object_selected == true, then the invariant "object_selected => is_authorized"
+        // is equivalent to "is_authorized". However, if we got here, we kind of already know that is_authorized is not
+        // true, in that case a condition wouldn't most likely have been returned in the first place. However, there can still
+        // be some weird corner cases where this happens, e.g. in "resource.name == resource.name" for create requests where it is
+        // kept unknown; and thus in order to keep precision, we invoke the SMT solver anyways to check.
+        let mut object_selected_expr: ast::Expr<()> = ast::ExprBuilder::new().val(true);
+
+        // The following values can be unknown today:
+        // For resource requests:
+        // - resource.apiGroup: "any" if unknown => no restrictions in object_selected
+        // - resource.resourceCombined: "any" if unknown => no restrictions in object_selected
+        // - resource.namespace: either "any" or In/NotIn semantics from the field selector.
+        // - resource.namespaceMetadata: The SAR request does not support enforcing any conditions on this, so needs to be kept as "any".
+        // - resource.name: "any" or In/NotIn semantics from the field selector.
+        // - resource.request.metadata: not supported, selectors operate only on data in storage
+        // - resource.request.vX: not supported, selectors operate only on data in storage
+        // - resource.stored.vX.metadata: field and label selectors can apply, but only to namespace and name.
+        // - resource.stored.vX: field and label selectors can apply to any selectable field.
+        // For non-resource requests:
+        // - resource.path: "any" if unknown => no restrictions in object_selected
+
+        match &attrs.request_type {
+            RequestType::Resource(resource_attrs) => {
+                object_selected_expr = apply_field_selectors_to_expr(object_selected_expr, resource_attrs.field_selector.as_ref(), &unknown_jsonpaths_to_uid, api_version, namespace_scoped);
+                object_selected_expr = apply_label_selectors_to_expr(object_selected_expr, resource_attrs.label_selector.as_ref(), &unknown_jsonpaths_to_uid);
+            }
+            RequestType::NonResource(_) => (),
+        }
+
+        //println!("jsonpaths_to_uid: {unknown_jsonpaths_to_uid:?}, api_version: {api_version}, namespace_scoped: {namespace_scoped}");
+        println!("object_selected_expr: {object_selected_expr}");
+        println!("is_authorized: {is_authorized}");
+
+        // TODO: Cedar to implement FromStr for PolicyID, and then use that.
+        let object_selected = cedar_policy::PolicySet::from_policies([
+            ast::Policy::from_when_clause(ast::Effect::Permit, object_selected_expr, ast::PolicyID::from_string("object_selected"), None).into()
+        ])?;
+
+        let well_typed_object_selected = cedar_policy_symcc::WellTypedPolicies::from_policies(
+            &object_selected,
+            &reqenv,
+            cedar_public_api_schema_ref,
+        )?;
+        // Convert the kube_invariants::PolicySet to a cedar_policy::PolicySet.
+        let is_authorized: cedar_policy::PolicySet = is_authorized.try_into()?;
+        let well_typed_is_authorized = cedar_policy_symcc::WellTypedPolicies::from_policies(
+            &is_authorized,
+            &reqenv,
+            cedar_public_api_schema_ref,
+        )?;
+        // Enforce invariant that object_selected => is_authorized.
+        // TODO: If some debug logging (or request-level, even, up to some DoS budget) is enabled,
+        // then give a concrete counterexample too.
+        let mut symcc = self.symcc_factory.new_sym_compiler()?;
+
+        let selectors_authorized = symcc
+            .check_implies_with_counterexample(
+                &well_typed_object_selected,
+                &well_typed_is_authorized,
+                &symenv,
+            )
+            .await?;
+        Ok(match selectors_authorized {
+            Some(_counterexample) => {
+                //let mut buf = Vec::new();
+                //counterexample.entities.write_to_json(&mut buf).unwrap();
+                //println!("counterexample: {}", String::from_utf8_lossy(&buf));
+                false
+            }
+            None => true,
+        })
+    }
+}
+
+fn apply_field_selectors_to_expr(mut object_selected_expr: ast::Expr<()>, field_selectors: Option<&Vec<k8s_authorizer::Selector>>, unknown_jsonpaths_to_uid: &HashMap<String, ast::EntityUID>, api_version: &str, namespace_scoped: bool) -> ast::Expr<()> {
+    if let Some(field_selectors) = field_selectors {
+        for field_selector in field_selectors {
+            if let Some(expr) = field_selector_to_expr(field_selector, &unknown_jsonpaths_to_uid, api_version, namespace_scoped) {
+                object_selected_expr = object_selected_expr.and(expr);
+            }
+        }
+    }
+    object_selected_expr
+}
+
+fn field_selector_to_expr(field_selector: &k8s_authorizer::Selector, unknown_jsonpaths_to_uid: &HashMap<String, ast::EntityUID>, api_version: &str, namespace_scoped: bool) -> Option<ast::Expr<()>> {
+    // Trim "." prefix, if any. TODO: This invariant should probably be in the parsing layer.
+    let key = field_selector.key.strip_prefix(".").unwrap_or_else(|| field_selector.key.as_str());
+
+    let (field_exists, field) = match key.strip_prefix("metadata.") {
+        Some("name") => {
+            // Note: If resource.name does not exist in unknown_jsonpaths_to_uid, it means that the variable is not used in is_authorized.
+            // If that is the case, then there is no need to restrict the variable's scope in object_selected, as whatever the variable
+            // value is, it won't affect the is_authorized value. Thus return None if not referenced.
+            (ast::Expr::val(true), ast::Expr::val(unknown_jsonpaths_to_uid.get("resource.name")?.clone()).get_attr("value"))
+        }
+        // TODO: Is the handling of namespace/cluster-scoped resources here correct?
+        Some("namespace") => {
+            (ast::Expr::val(namespace_scoped), ast::Expr::val(unknown_jsonpaths_to_uid.get("resource.namespace")?.clone()).get_attr("value"))
+        }
+        // TODO: Do we need to support other metadata fields?
+        // For now, ignoring the requirement here is sound, because objectSelected becomes wider than if this was implemented.
+        // TODO: Check if there are any metadata fieldselectors.
+        Some(_)  => return None,
+        _ => {
+            let object = ast::Expr::val(unknown_jsonpaths_to_uid.get(format!("resource.stored.{api_version}").as_str())?.clone());
+
+            let field_exists = super::fork::construct_exprs_extended_has::<ast::ExprBuilder<()>>(object.clone(), &NonEmpty::collect(key.split(".").map(|s| s.to_smolstr())).expect("str.split yields at least one item"), None);
+
+            let mut field = object;
+            for field_part in key.split(".") {
+                field = field.get_attr(field_part);
+            }
+
+            (field_exists, field)
+        }
+    };
+
+    match &field_selector.op {
+        k8s_authorizer::SelectorPredicate::Exists => {
+            // object has spec.nodeName
+            Some(field_exists)
+        }
+        k8s_authorizer::SelectorPredicate::NotExists => {
+            // !(object has spec.nodeName)
+            Some(field_exists.not())
+        },
+        k8s_authorizer::SelectorPredicate::In(values) => {
+            // TODO: Implement more than just string support; needs to check the type of the variable from the schema.
+            // TODO: We might want to optimize this when values.len() == 1 to use == or !=
+            let specified_set = ast::Expr::set(values.iter().sorted().map(|v| ast::Expr::val(v.as_str())));
+            // object has spec.nodeName && ["node1", "node2"].contains(object.spec.nodeName)
+            Some(field_exists.and(specified_set.contains(field)))
+        }
+        k8s_authorizer::SelectorPredicate::NotIn(values) => {
+            let specified_set = ast::Expr::set(values.iter().sorted().map(|v| ast::Expr::val(v.as_str())));
+            // object has spec.nodeName && !["node1", "node2"].contains(object.spec.nodeName)
+            Some(field_exists.and(specified_set.contains(field).not()))
+        }
+    }
+}
+
+fn apply_label_selectors_to_expr(mut object_selected_expr: ast::Expr<()>, label_selectors: Option<&Vec<k8s_authorizer::Selector>>, unknown_jsonpaths_to_uid: &HashMap<String, ast::EntityUID>) -> ast::Expr<()> {
+    if let Some(label_selectors) = label_selectors {
+        if label_selectors.len() > 0 {
+            if let Some(metadata) = unknown_jsonpaths_to_uid.get(format!("resource.stored.metadata").as_str()) {
+                let metadata_entity = ast::Expr::val(metadata.clone());
+
+                let labels_guard = metadata_entity.clone().has_attr("labels");
+                object_selected_expr = object_selected_expr.and(labels_guard);
+
+                let labels_entity = metadata_entity.get_attr("labels");
+                for label_selector in label_selectors {
+                    let label_expr = label_selector_to_expr(label_selector, labels_entity.clone());
+                    object_selected_expr = object_selected_expr.and(label_expr);
+                }
+            }
+        }
+    }
+    object_selected_expr
+}
+
+fn label_selector_to_expr(label_selector: &k8s_authorizer::Selector, labels_entity: ast::Expr<()>) -> ast::Expr<()> {
+    let label_exists = labels_entity.clone().has_tag(ast::Expr::val(label_selector.key.to_smolstr()));
+    match &label_selector.op {
+        k8s_authorizer::SelectorPredicate::Exists => {
+            // labels_entity.hasTag(key)
+            label_exists
+        }
+        k8s_authorizer::SelectorPredicate::NotExists => {
+            // !(labels_entity.hasTag(key))
+            label_exists.not()
+        },
+        k8s_authorizer::SelectorPredicate::In(values) => {
+            // TODO: We might want to optimize this when values.len() == 1 to use == or !=
+            let specified_set = ast::Expr::set(values.iter().sorted().map(|v| ast::Expr::val(v.as_str())));
+            // labels_entity.hasTag(key) && ["node1", "node2"].contains(labels_entity.getTag(key))
+            label_exists.and(specified_set.contains(labels_entity.get_tag(ast::Expr::val(label_selector.key.to_smolstr()))))
+        }
+        k8s_authorizer::SelectorPredicate::NotIn(values) => {
+            let specified_set = ast::Expr::set(values.iter().sorted().map(|v| ast::Expr::val(v.as_str())));
+            // labels_entity.hasTag(key) && !["node1", "node2"].contains(labels_entity.getTag(key))
+            label_exists.and(specified_set.contains(labels_entity.get_tag(ast::Expr::val(label_selector.key.to_smolstr()))).not())
+        }
+    }
+}
+
+trait WithExprBuilder: Sized {
+    fn and<T: Into<ast::Expr<()>>>(self, other: T) -> Self;
+    fn get_attr<T: Into<SmolStr>>(self, attr: T) -> Self;
+    fn has_attr<T: Into<SmolStr>>(self, attr: T) -> Self;
+    fn not(self) -> Self;
+    fn contains<T: Into<ast::Expr<()>>>(self, value: T) -> Self;
+    fn has_tag<T: Into<ast::Expr<()>>>(self, tag: T) -> Self;
+    fn get_tag<T: Into<ast::Expr<()>>>(self, tag: T) -> Self;
+}
+
+impl WithExprBuilder for ast::Expr<()> {
+    fn and<T: Into<ast::Expr<()>>>(self, other: T) -> Self {
+        ast::Expr::and(self, other.into())
+    }
+    fn get_attr<T: Into<SmolStr>>(self, attr: T) -> Self {
+        ast::Expr::get_attr(self, attr.into())
+    }
+    fn has_attr<T: Into<SmolStr>>(self, attr: T) -> Self {
+        ast::Expr::has_attr(self, attr.into())
+    }
+    fn not(self) -> Self {
+        ast::Expr::not(self)
+    }
+    fn contains<T: Into<ast::Expr<()>>>(self, value: T) -> Self {
+        ast::Expr::contains(self, value.into())
+    }
+    fn has_tag<T: Into<ast::Expr<()>>>(self, tag: T) -> Self {
+        ast::Expr::has_tag(self, tag.into())
+    }
+    fn get_tag<T: Into<ast::Expr<()>>>(self, tag: T) -> Self {
+        ast::Expr::get_tag(self, tag.into())
+    }
+}
+
+/*struct RestrictedExprBuilder {
+    expr: ast::Expr<()>,
+}
+
+impl RestrictedExprBuilder {
+    fn new<T: Into<ast::Expr<()>>>(expr: T) -> Self {
+        Self { expr: expr.into() }
+    }
+
+    fn and<T: Into<ast::Expr<()>>>(self, other: T) -> Self {
+        Self { expr: ast::Expr::and(self.expr, other.into()) }
+    }
+
+    fn build(self) -> ast::Expr<()> {
+        self.expr
+    }
+}*/
+
+
+
 mod test {
+    #[test]
+    fn test_field_selector_to_expr() {
+        use crate::k8s_authorizer;
+        use std::collections::{HashMap, HashSet};
+        let tests = vec![
+            (
+                "None if metadata.name is not referenced in is_authorized",
+                k8s_authorizer::Selector{
+                    key: "metadata.name".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["node1".to_string(), "node2".to_string()])),
+                },
+                HashMap::new(),
+                "whatever",
+                true,
+                None,
+            ),
+            (
+                "None if metadata.namespace is not referenced in is_authorized",
+                k8s_authorizer::Selector{
+                    key: "metadata.namespace".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["ns1".to_string(), "ns2".to_string()])),
+                },
+                HashMap::new(),
+                "whatever",
+                true,
+                None,
+            ),
+            (
+                "None if spec.nodeName is not referenced in is_authorized",
+                k8s_authorizer::Selector{
+                    key: "spec.nodeName".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["node1".to_string(), "node2".to_string()])),
+                },
+                HashMap::new(),
+                "whatever",
+                true,
+                None,
+            ),
+            (
+                "Simple metadata.name case, with In predicate and leading dot",
+                k8s_authorizer::Selector{
+                    key: ".metadata.name".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["node1".to_string(), "node2".to_string()])),
+                },
+                HashMap::from([("resource.name".to_string(), r#"meta::UnknownString::"foo""#.parse().unwrap())]),
+                "whatever",
+                true,
+                Some(r#"true && (["node1", "node2"].contains(meta::UnknownString::"foo"["value"]))"#.to_string()),
+            ),
+            (
+                "Simple metadata.namespace case, with In predicate and leading dot, for namespace-scoped resource",
+                k8s_authorizer::Selector{
+                    key: ".metadata.namespace".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["ns1".to_string(), "ns2".to_string()])),
+                },
+                HashMap::from([("resource.namespace".to_string(), r#"meta::UnknownString::"foo""#.parse().unwrap())]),
+                "whatever",
+                true,
+                Some(r#"true && (["ns1", "ns2"].contains(meta::UnknownString::"foo"["value"]))"#.to_string()),
+            ),
+            (
+                "Simple metadata.namespace case, with In predicate and leading dot, for cluster-scoped resource",
+                k8s_authorizer::Selector{
+                    key: ".metadata.namespace".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["ns1".to_string(), "ns2".to_string()])),
+                },
+                HashMap::from([("resource.namespace".to_string(), r#"meta::UnknownString::"foo""#.parse().unwrap())]),
+                "whatever",
+                false,
+                Some(r#"false && (["ns1", "ns2"].contains(meta::UnknownString::"foo"["value"]))"#.to_string()),
+            ),
+            (
+                "Simple spec.nodeName case, with In predicate",
+                k8s_authorizer::Selector{
+                    key: ".spec.nodeName".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["node1".to_string(), "node2".to_string()])),
+                },
+                HashMap::from([("resource.stored.v1".to_string(), r#"core::V1Node::"foo""#.parse().unwrap())]),
+                "v1",
+                true,
+                Some(r#"((core::V1Node::"foo" has "spec") && ((core::V1Node::"foo"["spec"]) has "nodeName")) && (["node1", "node2"].contains((core::V1Node::"foo"["spec"])["nodeName"]))"#.to_string()),
+            ),
+        ];
+        for (test_name, field_selector, unknown_jsonpaths_to_uid, api_version, namespace_scoped, expected_expr) in tests {
+            println!("test_name: {test_name}");
+            let got = super::field_selector_to_expr(&field_selector, &unknown_jsonpaths_to_uid, api_version, namespace_scoped);
+            if let Some(expr) = got.clone() {
+                println!("got: {expr}");
+            }
+            assert_eq!(got.map(|e| e.to_string()), expected_expr);
+        }
+    }
+
+    #[test]
+    fn test_apply_label_selectors_to_expr() {
+        use crate::k8s_authorizer;
+        use cedar_policy_core::ast;
+        use std::collections::{HashMap, HashSet};
+        let tests = vec![
+            (
+                "None if resource.stored.metadata.labels.foo is not referenced in is_authorized",
+                vec![k8s_authorizer::Selector{
+                    key: "foo".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["bar".to_string(), "baz".to_string()])),
+                }],
+                HashMap::new(),
+                "true",
+            ),
+            (
+                "Simple case, with In predicate",
+                vec![k8s_authorizer::Selector{
+                    key: "foo".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["bar".to_string(), "baz".to_string()])),
+                }],
+                HashMap::from([("resource.stored.metadata".to_string(), r#"meta::V1ObjectMeta::"foo""#.parse().unwrap())]),
+                r#"(true && (meta::V1ObjectMeta::"foo" has "labels")) && (((meta::V1ObjectMeta::"foo"["labels"]).hasTag("foo")) && (["bar", "baz"].contains((meta::V1ObjectMeta::"foo"["labels"]).getTag("foo"))))"#,
+            ),
+            (
+                "One In and one NotIn predicate; metadata has labels not duplicated",
+                vec![k8s_authorizer::Selector{
+                    key: "foo".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::In(HashSet::from(["bar".to_string(), "baz".to_string()])),
+                }, k8s_authorizer::Selector{
+                    key: "bar".to_string(),
+                    op: k8s_authorizer::SelectorPredicate::NotIn(HashSet::from(["qux".to_string(), "quux".to_string()])),
+                }],
+                HashMap::from([("resource.stored.metadata".to_string(), r#"meta::V1ObjectMeta::"foo""#.parse().unwrap())]),
+                r#"(
+                    (
+                     true && 
+                     (meta::V1ObjectMeta::"foo" has "labels")
+                    ) && 
+                    (
+                     ((meta::V1ObjectMeta::"foo"["labels"]).hasTag("foo")) && 
+                     (["bar", "baz"].contains((meta::V1ObjectMeta::"foo"["labels"]).getTag("foo"))
+                    )
+                   )
+                  ) && 
+                  (!(
+                     ((meta::V1ObjectMeta::"foo"["labels"]).hasTag("bar")) && 
+                     (["quux", "qux"].contains((meta::V1ObjectMeta::"foo"["labels"]).getTag("bar"))
+                    )
+                  )
+                 )"#,
+            ),
+        ];
+        for (test_name, label_selectors, unknown_jsonpaths_to_uid, expected_expr) in tests {
+            println!("test_name: {test_name}");
+            let mut object_selected_expr = ast::Expr::val(true);
+            object_selected_expr = super::apply_label_selectors_to_expr(object_selected_expr, Some(&label_selectors), &unknown_jsonpaths_to_uid);
+            assert_eq!(object_selected_expr.to_string(), remove_whitespace(expected_expr.to_string()));
+        }
+    }
+
+    #[cfg(test)]
+    fn remove_whitespace(mut current: String) -> String {
+        loop {
+            let replaced = current.replace("  ", " ").replace("\n", "");
+            if replaced == current {
+                return current;
+            }
+            current = replaced;
+        }
+    }
 
     #[tokio::test]
     async fn test_symcc() {

--- a/src/cedar_authorizer/testfiles/is_authorized.cedar
+++ b/src/cedar_authorizer/testfiles/is_authorized.cedar
@@ -8,7 +8,7 @@ permit(
     resource.resourceCombined == "pods" &&
     !(resource has request) &&
     // Actual policy
-    resource has stored &&
+    resource has stored.metadata.labels &&
     (if resource.stored.metadata.labels.hasTag("env") then
         resource.stored.metadata.labels.getTag("env") != "prod"
      else true) &&
@@ -26,7 +26,7 @@ permit(
     resource.resourceCombined == "pods" &&
     !(resource has request) &&
     // Actual policy
-    resource has stored &&
+    resource has stored.metadata.labels &&
     resource.stored.metadata.labels.hasTag("env") && 
     resource.stored.metadata.labels.getTag("env") == "test"
 };

--- a/src/cedar_authorizer/testfiles/object_selected.cedar
+++ b/src/cedar_authorizer/testfiles/object_selected.cedar
@@ -8,7 +8,7 @@ permit(
     resource.resourceCombined == "pods" &&
     !(resource has request) &&
     // Actual policy
-    resource has stored &&
+    resource has stored.metadata.labels &&
     resource.stored.metadata.labels.hasTag("env") && 
     ["test", "dev"].contains(resource.stored.metadata.labels.getTag("env")) &&
     resource.stored.metadata.labels.hasTag("owner") && 

--- a/src/cedar_authorizer/testfiles/simple.cedar
+++ b/src/cedar_authorizer/testfiles/simple.cedar
@@ -9,13 +9,13 @@ when { ["admin", "superadmin"].contains(principal.username) };
 // (resource has namespace && resource.namespace.name == "supersecret") ||
 forbid (
     principal,
-    action == k8s::Action::"get",
+    action in [k8s::Action::"*"], // Testing that the entity hierarchy is correctly propagated to TPE
     resource
 )
 when
 {
     resource has namespace &&
-    resource.namespace.name == "supersecret" &&
+    resource.namespace == "supersecret" &&
     (principal is k8s::UnauthenticatedUser ||
      principal.username != "superadmin")
 };
@@ -38,7 +38,7 @@ when { resource.path == "*" };
 
 permit (
     principal is k8s::ServiceAccount,
-    action in [k8s::Action::"get", k8s::Action::"list"],
+    action in [k8s::Action::"create"],
     resource
 )
 when
@@ -46,9 +46,10 @@ when
     resource.apiGroup == "" &&
     resource.resourceCombined == "pods" &&
     resource has namespace &&
-    resource.namespace.name == principal.serviceAccountNamespace &&
-    resource.namespace.metadata.labels.hasTag("serviceaccounts-allowed") &&
-    resource.namespace.metadata.labels.getTag("serviceaccounts-allowed") == "true"
+    resource.namespace == principal.serviceAccountNamespace &&
+    resource has namespaceMetadata.labels &&
+    resource.namespaceMetadata.labels.hasTag("serviceaccounts-allowed") &&
+    resource.namespaceMetadata.labels.getTag("serviceaccounts-allowed") == "true"
 };
 
 permit (
@@ -63,7 +64,7 @@ permit (
     action,
     resource
 )
-when { principal.groups.contains("lucas") && resource has namespace && resource.namespace.name == "notinstorage" };
+when { principal.groups.contains("lucas") && resource has namespace && resource.namespace == "notinstorage" };
 
 permit (
     principal is k8s::User,
@@ -84,12 +85,33 @@ permit (
     action == k8s::Action::"watch",
     resource
 )
-when { principal.username == "singleitemwatch" && resource has namespace && resource.namespace.name == "foo" && resource.name == "bar" };
+when { principal.username == "singleitemwatch" && resource has namespace && resource.namespace == "foo" && resource.name == "bar" };
 
 
 permit (
     principal is k8s::Node,
-    action == k8s::Action::"get",
+    action == k8s::Action::"watch",
     resource is core::pods
 )
-when { resource has stored && resource.stored has v1.spec && resource.stored.v1.spec.nodeName == principal.nodeName };
+when { resource has stored.v1.spec && resource.stored.v1.spec.nodeName == principal.nodeName };
+
+// Allow contour and istio ingress controllers to list and watch secrets, but only if:
+// - The secret allows either all ingresses (through the "*" label value) or the specific ingress controller (through the ingress controller's service account name)
+// - The secret's clearance level is not supersecret or confidential
+permit (
+    principal is k8s::ServiceAccount,
+    action in [k8s::Action::"list", k8s::Action::"watch"],
+    resource is core::secrets // TODO: Should label selector authorization be allowed, even though we don't know the resource type?
+)
+when {
+    ["contour", "istio"].contains(principal.serviceAccountName) &&
+    resource has stored.metadata.labels &&
+    resource.stored.metadata.labels.hasTag("allowed-ingress") &&
+    (resource.stored.metadata.labels.getTag("allowed-ingress") == "*" || resource.stored.metadata.labels.getTag("allowed-ingress") == principal.serviceAccountName) &&
+    // Clearance labelselector must be present
+    resource.stored.metadata.labels.hasTag("clearancelevel")
+} unless {
+    // Clearance level must not be supersecret or confidential
+    resource.stored.metadata.labels.getTag("clearancelevel") == "supersecret" ||
+    resource.stored.metadata.labels.getTag("clearancelevel") == "confidential"
+};

--- a/src/cedar_authorizer/testfiles/simple.cedarschema
+++ b/src/cedar_authorizer/testfiles/simple.cedarschema
@@ -25,44 +25,46 @@ namespace k8s {
     "username": __cedar::String
   };
 
-  entity Namespace = {
-    "metadata": meta::V1ObjectMeta,
-    "name": __cedar::String
-  };
-
   entity Resource = {
     "apiGroup": __cedar::String,
     // "apiVersion": __cedar::String,
-    "name": __cedar::String, // TODO: Rewrite the schema to use meta::UnknownString
-    "namespace"?: k8s::Namespace,
+    "name": __cedar::String,
+    // TODO: If Kubernetes had a distinction between "unset" and "any" namespace, this would be an optional field,
+    // that:
+    // - when the SAR says "unset", would be unset (i.e, "resource has namespace" would be false), and
+    // - when the SAR says "any", would be "any" (i.e, "resource has namespace" would be true), and
+    // - when the SAR says "exact", would be the exact namespace name (i.e, "resource has namespace" would be true).
+    // As we do not have this distinction, we cannot provide a way for checking if the namespace is "set" or "unset",
+    // and thus this is a required field.
+    "namespace": __cedar::String,
     "resourceCombined": __cedar::String
   };
 
+  action "create" in ["*"] appliesTo {
+    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
+    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
+    context: {}
+  };
+
+  action "get" in ["*"] appliesTo {
+    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
+    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
+    context: {}
+  };
+
+  action "list" in ["*"] appliesTo {
+    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
+    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
+    context: {}
+  };
+
+  action "watch" in ["*"] appliesTo {
+    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
+    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
+    context: {}
+  };
+
   action "*" appliesTo {
-    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
-    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
-    context: {}
-  };
-
-  action "create" appliesTo {
-    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
-    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
-    context: {}
-  };
-
-  action "get" appliesTo {
-    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
-    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
-    context: {}
-  };
-
-  action "list" appliesTo {
-    principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
-    resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
-    context: {}
-  };
-
-  action "watch" appliesTo {
     principal: [k8s::User, k8s::ServiceAccount, k8s::Node, k8s::UnauthenticatedUser],
     resource: [k8s::Resource, core::pods, core::pods_status, core::nodes, core::secrets],
     context: {}
@@ -112,14 +114,15 @@ namespace core {
     "apiGroup": __cedar::String,          // always ""
     "resourceCombined": __cedar::String,  // always "pods"
     "name": __cedar::String,
-    "namespace": k8s::Namespace,
+    "namespace": __cedar::String,
+    "namespaceMetadata"?: meta::V1ObjectMeta,
     "request"?: core::VersionedPod,
     "stored"?: core::VersionedPod
   };
   type VersionedPod = {
     "apiVersion": __cedar::String,        // always "v1"
     "kind": __cedar::String,              // always "Pod"
-    "metadata": meta::V1ObjectMeta,
+    "metadata"?: meta::V1ObjectMeta,
     "v1"?: core::V1Pod
   };
   entity V1Pod = {
@@ -139,7 +142,8 @@ namespace core {
     "apiGroup": __cedar::String,          // always ""
     "resourceCombined": __cedar::String,  // always "secrets"
     "name": __cedar::String,
-    "namespace": k8s::Namespace,
+    "namespace": __cedar::String,
+    "namespaceMetadata"?: meta::V1ObjectMeta,
     "request"?: core::VersionedSecret,
     "stored"?: core::VersionedSecret
   };
@@ -161,7 +165,8 @@ namespace core {
     "apiGroup": __cedar::String,          // always ""
     "resourceCombined": __cedar::String,  // always "pods/status"
     "name": __cedar::String,
-    "namespace": k8s::Namespace,
+    "namespace": __cedar::String,
+    "namespaceMetadata"?: meta::V1ObjectMeta,
     "request"?: core::VersionedPodStatus,
     "stored"?: core::VersionedPodStatus
   };
@@ -188,10 +193,10 @@ namespace meta {
   } tags Set<__cedar::String>;
 
   entity V1ObjectMeta = {
-    "annotations": meta::StringToStringMap,
+    "annotations"?: meta::StringToStringMap,
     "deleted": __cedar::Bool,
-    "finalizers": Set<__cedar::String>,
-    "labels": meta::StringToStringMap,
+    "finalizers"?: Set<__cedar::String>,
+    "labels"?: meta::StringToStringMap,
     "uid"?: __cedar::String
   };
 }

--- a/src/k8s_authorizer/authorizer.rs
+++ b/src/k8s_authorizer/authorizer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use crate::k8s_authorizer::{NonResourceAttributes, RequestType, StarWildcardStringSelector};
+use crate::k8s_authorizer::{CombinedResource, NonResourceAttributes, RequestType, StarWildcardStringSelector};
 
 use super::err::ParseError;
 use crate::cedar_authorizer::kube_invariants;
@@ -12,16 +12,22 @@ use super::err::AuthorizerError;
 use super::selectors::Selector;
 use cedar_policy_core::ast::{self, EntityUID};
 
-pub trait KubernetesAuthorizer {
+pub trait KubernetesAuthorizer: Sync {
     /// Determines whether the request is authorized.
     /// Returns a Response object with the decision, reason, and errors, or an unexpected error.
-    fn is_authorized(&self, attrs: Attributes) -> Result<Response, AuthorizerError>;
+    fn is_authorized(
+        &self,
+        attrs: Attributes,
+    ) -> impl std::future::Future<Output = Result<Response, AuthorizerError>> + Send;
 
     /// Convenience method that converts the Result<Response, AuthorizerError> into a Response.
     /// If the Result is an unexpected error, NoOpinion is returned, and the errors are added to the Response.
     /// If the Result is ok, the Response is returned as is.
-    fn is_authorized_response(&self, attrs: Attributes) -> Response {
-        self.is_authorized(attrs).into()
+    fn is_authorized_response(
+        &self,
+        attrs: Attributes,
+    ) -> impl std::future::Future<Output = Response> + Send {
+        async move { self.is_authorized(attrs).await.into() }
     }
 }
 
@@ -155,6 +161,21 @@ impl Attributes {
     pub fn from_subject_access_review(value: &SubjectAccessReview) -> Result<Self, ParseError> {
         Self::try_from(value.clone())
     }
+    pub fn supports_conditional_authorization(&self) -> Option<(String, String, String)> {
+        match &self.request_type {
+            RequestType::Resource(ResourceAttributes { api_group, api_version, resource, .. }) => {
+                match (api_group, api_version, resource) {
+                    (StarWildcardStringSelector::Exact(api_group),
+                    StarWildcardStringSelector::Exact(api_version),
+                    CombinedResource::ResourceOnly { .. } | CombinedResource::ResourceSubresource { .. }) => {
+                        Some((api_group.clone(), api_version.clone(), resource.to_string()))
+                    }
+                    _ => None,
+                }
+            },
+            RequestType::NonResource(_) => None,
+        }
+    }
 }
 
 impl TryFrom<SubjectAccessReview> for Attributes {
@@ -188,13 +209,8 @@ impl TryFrom<SubjectAccessReview> for Attributes {
                             },
                             StarWildcardStringSelector::Any => StarWildcardStringSelector::Any,
                         },
-                        field_selector: match (
-                            verb.supports_selectors(),
-                            resource_attrs.field_selector,
-                        ) {
-                            (false, _) => None, // Don't parse if the verb does not support it. TODO: error or warning?
-                            (true, None) => None,
-                            (true, Some(selector_params)) => {
+                        field_selector: match resource_attrs.field_selector {
+                            Some(selector_params) => {
                                 match (selector_params.raw_selector, selector_params.requirements) {
                                     (Some(_), _) => {
                                         return Err(ParseError::InvalidFieldSelectorRequirement(
@@ -209,14 +225,10 @@ impl TryFrom<SubjectAccessReview> for Attributes {
                                     (None, None) => None,
                                 }
                             }
+                            None => None,
                         },
-                        label_selector: match (
-                            verb.supports_selectors(),
-                            resource_attrs.label_selector,
-                        ) {
-                            (false, _) => None, // Don't parse if the verb does not support it. TODO: error or warning?
-                            (true, None) => None,
-                            (true, Some(selector_params)) => {
+                        label_selector: match resource_attrs.label_selector {
+                            Some(selector_params) => {
                                 match (selector_params.raw_selector, selector_params.requirements) {
                                     (Some(_), _) => {
                                         return Err(ParseError::InvalidLabelSelectorRequirement(
@@ -231,6 +243,7 @@ impl TryFrom<SubjectAccessReview> for Attributes {
                                     (None, None) => None,
                                 }
                             }
+                            None => None,
                         },
                     }),
                 })

--- a/src/k8s_authorizer/authorizer.rs
+++ b/src/k8s_authorizer/authorizer.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use crate::k8s_authorizer::{CombinedResource, NonResourceAttributes, RequestType, StarWildcardStringSelector};
+use crate::k8s_authorizer::{
+    CombinedResource, NonResourceAttributes, RequestType, StarWildcardStringSelector,
+};
 
 use super::err::ParseError;
 use crate::cedar_authorizer::kube_invariants;
@@ -163,15 +165,19 @@ impl Attributes {
     }
     pub fn supports_conditional_authorization(&self) -> Option<(String, String, String)> {
         match &self.request_type {
-            RequestType::Resource(ResourceAttributes { api_group, api_version, resource, .. }) => {
-                match (api_group, api_version, resource) {
-                    (StarWildcardStringSelector::Exact(api_group),
+            RequestType::Resource(ResourceAttributes {
+                api_group,
+                api_version,
+                resource,
+                ..
+            }) => match (api_group, api_version, resource) {
+                (
+                    StarWildcardStringSelector::Exact(api_group),
                     StarWildcardStringSelector::Exact(api_version),
-                    CombinedResource::ResourceOnly { .. } | CombinedResource::ResourceSubresource { .. }) => {
-                        Some((api_group.clone(), api_version.clone(), resource.to_string()))
-                    }
-                    _ => None,
-                }
+                    CombinedResource::ResourceOnly { .. }
+                    | CombinedResource::ResourceSubresource { .. },
+                ) => Some((api_group.clone(), api_version.clone(), resource.to_string())),
+                _ => None,
             },
             RequestType::NonResource(_) => None,
         }

--- a/src/k8s_authorizer/err.rs
+++ b/src/k8s_authorizer/err.rs
@@ -1,4 +1,14 @@
 #[derive(Debug, thiserror::Error)]
+pub enum SymbolicEvaluationError {
+    #[error(transparent)]
+    SymccError(#[from] cedar_policy_symcc::err::Error),
+    #[error(transparent)]
+    PolicySetError(#[from] cedar_policy::PolicySetError),
+    #[error(transparent)]
+    SolverFactoryError(#[from] crate::cedar_authorizer::symcc::SolverFactoryError),
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum AuthorizerError {
     #[error("verb {0} is not supported")]
     UnsupportedVerb(String),
@@ -13,8 +23,6 @@ pub enum AuthorizerError {
     TPEError(#[from] cedar_policy_core::tpe::err::TPEError),
     #[error(transparent)]
     EntitiesError(Box<cedar_policy_core::tpe::err::EntitiesError>),
-    #[error("No Kubernetes namespace found in schema")]
-    NoKubernetesNamespace,
     #[error(transparent)]
     EarlyEvaluationError(#[from] crate::cedar_authorizer::kube_invariants::EarlyEvaluationError),
 
@@ -28,6 +36,10 @@ pub enum AuthorizerError {
     CedarToCelError(#[from] crate::cedar_authorizer::cel::CedarToCelError),
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
+    #[error(transparent)]
+    SymbolicEvaluationError(#[from] SymbolicEvaluationError),
+    #[error(transparent)]
+    EntityAttrEvaluationError(#[from] cedar_policy_core::ast::EntityAttrEvaluationError),
 }
 
 impl From<cedar_policy_core::parser::err::ParseErrors> for AuthorizerError {

--- a/src/k8s_authorizer/selectors.rs
+++ b/src/k8s_authorizer/selectors.rs
@@ -11,7 +11,6 @@ pub struct Selector {
     // For a required field, Exists is always true, and NotExists is always false.
     // TODO: This should probably be populated at another layer, when a schema is available.
     // pub nullable: bool,
-
     pub op: SelectorPredicate,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,19 +5,15 @@ use axum::{
 };
 use itertools::Itertools;
 use kubernetes_cedar_authorizer::{
-    cedar_authorizer::{self, kubestore::KubeStoreImpl, symcc::LocalSolverFactory},
+    cedar_authorizer::{self, symcc::LocalSolverFactory},
     k8s_authorizer::{self, KubernetesAuthorizer},
 };
 
 use axum_server::tls_rustls::RustlsConfig;
 use cedar_policy::PolicySet;
-use k8s_openapi::api::{
-    authorization::v1::{SubjectAccessReview, SubjectAccessReviewStatus},
-    core::v1 as corev1,
-};
+use k8s_openapi::api::authorization::v1::{SubjectAccessReview, SubjectAccessReviewStatus};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio_util::sync::CancellationToken;
 
 use axum::extract::State;
 use cedar_policy_core::{extensions::Extensions, validator::json_schema::Fragment};
@@ -118,14 +114,6 @@ async fn run() -> Result<(), SetupError> {
     let policy_file = std::fs::read_to_string(policy_file).map_err(SetupError::todo)?;
     let policies = policy_file.parse::<PolicySet>().map_err(SetupError::todo)?;
 
-    let cancel = CancellationToken::new();
-
-    // Infer the runtime environment and try to create a Kubernetes Client
-    let kube_client = kube::Client::try_default().await?;
-
-    let namespaces: kube::Api<corev1::Namespace> = kube::Api::all(kube_client);
-    let namespace_store = KubeStoreImpl::new(namespaces, cancel.clone());
-
     let schema =
         cedar_authorizer::kube_invariants::Schema::new(schema).map_err(SetupError::todo)?;
     let policies = cedar_authorizer::kube_invariants::PolicySet::new(
@@ -135,7 +123,7 @@ async fn run() -> Result<(), SetupError> {
     .map_err(SetupError::todo)?;
 
     let authorizer = Arc::new(
-        cedar_authorizer::CedarKubeAuthorizer::new(policies, namespace_store, LocalSolverFactory)
+        cedar_authorizer::CedarKubeAuthorizer::new(policies, LocalSolverFactory)
             .map_err(SetupError::todo)?,
     );
 
@@ -189,7 +177,6 @@ impl SetupError {
 }
 
 type CedarKubeAuthorizer = cedar_authorizer::authorizer::CedarKubeAuthorizer<
-    cedar_authorizer::kubestore::KubeStoreImpl<corev1::Namespace>,
     cedar_authorizer::symcc::LocalSolverFactory,
     cedar_authorizer::LocalSolver,
 >;


### PR DESCRIPTION
- Split namespace entity into two parts for more precision on what is unknown,
- Make labels/annotations optional, and
- Implement use of symcc to resolve whether selector requests should be allowed, like described in section 5.6 in my thesis.